### PR TITLE
🥵 :: 중복된 select 제거

### DIFF
--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/adapter/auth/ReadCurrentUserAdapter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/adapter/auth/ReadCurrentUserAdapter.kt
@@ -1,19 +1,15 @@
 package com.info.maeumgagym.adapter.auth
 
 import com.info.maeumgagym.auth.port.out.ReadCurrentUserPort
-import com.info.maeumgagym.global.exception.UnAuthorizedException
+import com.info.maeumgagym.global.security.principle.CustomUserDetails
 import com.info.maeumgagym.user.model.User
-import com.info.maeumgagym.user.port.out.FindUserByOAuthIdPort
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 
 @Component
-class ReadCurrentUserAdapter(
-    private val findUserByOAuthIdPort: FindUserByOAuthIdPort
-) : ReadCurrentUserPort {
+class ReadCurrentUserAdapter : ReadCurrentUserPort {
 
-    override fun readCurrentUser(): User = findUserByOAuthIdPort.findUserByOAuthId(
+    override fun readCurrentUser(): User =
         // jwt filter에서 집어 넣은 user를 context holder에서 꺼내오기
-        SecurityContextHolder.getContext().authentication.name
-    ) ?: throw UnAuthorizedException
+        (SecurityContextHolder.getContext().authentication.details as CustomUserDetails).user
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/adapter/auth/ReadCurrentUserAdapter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/adapter/auth/ReadCurrentUserAdapter.kt
@@ -11,5 +11,5 @@ class ReadCurrentUserAdapter : ReadCurrentUserPort {
 
     override fun readCurrentUser(): User =
         // jwt filter에서 집어 넣은 user를 context holder에서 꺼내오기
-        (SecurityContextHolder.getContext().authentication.details as CustomUserDetails).user
+        (SecurityContextHolder.getContext().authentication.principal as CustomUserDetails).user
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/security/principle/CustomUserDetails.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/security/principle/CustomUserDetails.kt
@@ -6,7 +6,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 
 class CustomUserDetails(
-    private val user: User
+    val user: User
 ) : UserDetails {
     override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
         val authList: MutableList<SimpleGrantedAuthority> = mutableListOf()

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/security/principle/CustomUserDetails.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/security/principle/CustomUserDetails.kt
@@ -8,11 +8,11 @@ import org.springframework.security.core.userdetails.UserDetails
 class CustomUserDetails(
     val user: User
 ) : UserDetails {
-    override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
-        val authList: MutableList<SimpleGrantedAuthority> = mutableListOf()
-        user.roles.forEach { authList.add(SimpleGrantedAuthority(it.name)) }
-        return authList
-    }
+
+    override fun getAuthorities(): MutableCollection<out GrantedAuthority> =
+        user.roles.map {
+            SimpleGrantedAuthority(it.name)
+        }.toMutableList()
 
     override fun getPassword(): String? = null
 

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/user/junit5/ReadCurrentUserAdapterTests.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/user/junit5/ReadCurrentUserAdapterTests.kt
@@ -50,21 +50,6 @@ class ReadCurrentUserAdapterTests @Autowired constructor(
     /**
      * @see ReadCurrentUserAdapter.readCurrentUser
      * @when 실패 상황
-     * @success Authentication 내부의 user가 UserRepository에 존재하지 않으므로 실패
-     * @fail Authentication 내부의 user가 존재하는 유저인지 확인하는 로직이 누락되었는지 확인
-     */
-    @Test
-    fun readCurrentUserWithNonExistsUser() {
-        user.saveInRepository(userRepository).saveInContext(userMapper)
-        userRepository.delete(user)
-        Assertions.assertThrows(UnAuthorizedException::class.java) {
-            readCurrentUserAdapter.readCurrentUser()
-        }
-    }
-
-    /**
-     * @see ReadCurrentUserAdapter.readCurrentUser
-     * @when 실패 상황
      * @success Context가 비어있는 상태에서 currentUser()를 호출해 NPE 발생
      */
     @Test

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/user/junit5/WithdrawalUserServiceTests.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/user/junit5/WithdrawalUserServiceTests.kt
@@ -50,20 +50,4 @@ class WithdrawalUserServiceTests @Autowired constructor(
         Assertions.assertNull(userRepository.findByIdOrNull(user.id!!))
         Assertions.assertNotNull(deletedAtRepository.findByIdOrNull(user.id!!))
     }
-
-    /**
-     * @see WithdrawalUserService.withdrawal
-     * @when 실패 상황
-     * @success 이미 탈퇴한 유저이기 때문에 readCurrentUser()에서 UnAuthorizedException 발생
-     *  실제 플로우상, 탈퇴한 유저는 토큰을 발급할 수 없으므로 해당 상황은 존재할 수 없음
-     *  @see ReadCurrentUserAdapter.readCurrentUser
-     * @fail DeletedAtJpaEntity를 찾고, 예외를 발생시키는 로직이 존재하는지 확인
-     */
-    @Test
-    fun withdrawalAlreadyDidUser() {
-        withdrawalUserService.withdrawal()
-        Assertions.assertThrows(UnAuthorizedException::class.java) {
-            withdrawalUserService.withdrawal()
-        }
-    }
 }


### PR DESCRIPTION
- readCurrentUserAdapter에서 select문을 날려 user를 얻지 않고 authentication에서 추출하도록 수정
- CustomUserDetails가 감싸고 있는 user의 getter 활성화
- CustomUserDetails의 getAuthorities 리팩토링