### PR TITLE
📝 :: 와카타임 테스트 코드 작성

### DIFF
--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/common/exception/ErrorCode.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/common/exception/ErrorCode.kt
@@ -43,8 +43,5 @@ enum class ErrorCode(
     DUPLICATED_NICKNAME(409, "Duplicated Nickname"),
     ALREADY_EXIST_USER(409, "Already Exists User"),
     ALREADY_EXIST_PICKLE(409, "Already Exists Pickle"),
-    ALREADY_STARTED_WAKA(409, "Already Started Wakatime"),
-
-    // Test
-    MISMATCH_QUOTE_AND_QUOTER(500, "Mismatch Quote and Quoter")
+    ALREADY_STARTED_WAKA(409, "Already Started Wakatime")
 }

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/quote/exception/MismatchQuoteAndQuoterException.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/quote/exception/MismatchQuoteAndQuoterException.kt
@@ -1,6 +1,6 @@
 package com.info.maeumgagym.domain.quote.exception
 
-import com.info.maeumgagym.common.exception.ErrorCode
-import com.info.maeumgagym.common.exception.MaeumGaGymException
+import com.info.maeumgagym.global.MaeumGaGymTestException
+import com.info.maeumgagym.global.TestErrorCode
 
-internal object MismatchQuoteAndQuoterException : MaeumGaGymException(ErrorCode.MISMATCH_QUOTE_AND_QUOTER)
+internal object MismatchQuoteAndQuoterException : MaeumGaGymTestException(TestErrorCode.MISMATCH_QUOTE_AND_QUOTER)

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/WakatimeTests.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/WakatimeTests.kt
@@ -1,6 +1,5 @@
 package com.info.maeumgagym.domain.wakatime
 
-import com.info.maeumgagym.domain.auth.AuthTestModule
 import com.info.maeumgagym.domain.auth.AuthTestModule.saveInContext
 import com.info.maeumgagym.domain.user.entity.UserJpaEntity
 import com.info.maeumgagym.domain.user.mapper.UserMapper
@@ -127,9 +126,18 @@ class WakatimeTests @Autowired constructor(
     }
 
     @Test
+    fun runSchedulerAndStart() {
+        startWakatimeUseCase.startWakatime()
+        wakaTimeScheduler.restartAllWakaTime()
+        user.saveInContext(userMapper)
+        Assertions.assertThrows(AlreadyWakaStartedException::class.java) {
+            startWakatimeUseCase.startWakatime()
+        }
+    }
+
+    @Test
     fun runSchedulerAndEnd() {
         startWakatimeUseCase.startWakatime()
-        user.setWakaStartedAtToBefore10Seconds().saveInContext(userMapper)
         wakaTimeScheduler.restartAllWakaTime()
 
         user.setWakaStartedAtToBefore10Seconds().saveInRepository(userRepository).saveInContext(userMapper)

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/WakatimeTests.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/WakatimeTests.kt
@@ -1,0 +1,83 @@
+package com.info.maeumgagym.domain.wakatime
+
+import com.info.maeumgagym.domain.auth.AuthTestModule
+import com.info.maeumgagym.domain.auth.AuthTestModule.saveInContext
+import com.info.maeumgagym.domain.user.entity.UserJpaEntity
+import com.info.maeumgagym.domain.user.mapper.UserMapper
+import com.info.maeumgagym.domain.user.module.UserTestModule
+import com.info.maeumgagym.domain.user.module.UserTestModule.saveInRepository
+import com.info.maeumgagym.domain.user.repository.UserRepository
+import com.info.maeumgagym.domain.wakatime.entity.WakaTimeJpaEntity
+import com.info.maeumgagym.domain.wakatime.exception.WakatimeDoesNotSavedException
+import com.info.maeumgagym.domain.wakatime.module.WakatimeTestModule
+import com.info.maeumgagym.domain.wakatime.module.WakatimeTestModule.setWakaStartedAtToBefore10Seconds
+import com.info.maeumgagym.domain.wakatime.repository.WakaTimeRepository
+import com.info.maeumgagym.wakatime.exception.AlreadyWakaStartedException
+import com.info.maeumgagym.wakatime.exception.WakaStartedNotYetException
+import com.info.maeumgagym.wakatime.port.`in`.EndWakatimeUseCase
+import com.info.maeumgagym.wakatime.port.`in`.StartWakatimeUseCase
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@Transactional
+@SpringBootTest
+class WakatimeTests @Autowired constructor(
+    private val startWakatimeUseCase: StartWakatimeUseCase,
+    private val endWakatimeUseCase: EndWakatimeUseCase,
+    private val wakaTimeRepository: WakaTimeRepository,
+    private val userRepository: UserRepository,
+    private val userMapper: UserMapper
+) {
+
+    private lateinit var user: UserJpaEntity
+
+    @BeforeEach
+    fun initialize() {
+        user = UserTestModule.createTestUser().saveInRepository(userRepository).saveInContext(userMapper)
+    }
+
+    @Test
+    fun start() {
+        startWakatimeUseCase.startWakatime()
+        Assertions.assertNotNull(user.wakaStartedAt)
+    }
+
+    @Test
+    fun startWhenAlreadyStarted() {
+        startWakatimeUseCase.startWakatime()
+        user.saveInContext(userMapper)
+        Assertions.assertThrows(AlreadyWakaStartedException::class.java) {
+            startWakatimeUseCase.startWakatime()
+        }
+    }
+
+    @Test
+    fun end() {
+        startWakatimeUseCase.startWakatime()
+        user.setWakaStartedAtToBefore10Seconds().saveInRepository(userRepository).saveInContext(userMapper)
+        endWakatimeUseCase.endWakatime()
+
+        Assertions.assertDoesNotThrow {
+            WakatimeTestModule.isSimilarWithAllowableErrorSize(
+                a = 10,
+                b = wakaTimeRepository.findByIdOrNull(
+                    WakaTimeJpaEntity.IdClass(user.id!!, LocalDate.now())
+                )?.waka ?: throw WakatimeDoesNotSavedException,
+                allowableErrorSize = 2
+            )
+        }
+    }
+
+    @Test
+    fun endWhenNotStarted() {
+        Assertions.assertThrows(WakaStartedNotYetException::class.java) {
+            endWakatimeUseCase.endWakatime()
+        }
+    }
+}

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/exception/ErrorTooBigException.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/exception/ErrorTooBigException.kt
@@ -1,0 +1,7 @@
+package com.info.maeumgagym.domain.wakatime.exception
+
+import com.info.maeumgagym.global.MaeumGaGymTestException
+import com.info.maeumgagym.global.TestErrorCode
+
+internal object ErrorTooBigException : MaeumGaGymTestException(TestErrorCode.ERROR_TOO_BIG) {
+}

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/exception/ErrorTooBigException.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/exception/ErrorTooBigException.kt
@@ -3,5 +3,4 @@ package com.info.maeumgagym.domain.wakatime.exception
 import com.info.maeumgagym.global.MaeumGaGymTestException
 import com.info.maeumgagym.global.TestErrorCode
 
-internal object ErrorTooBigException : MaeumGaGymTestException(TestErrorCode.ERROR_TOO_BIG) {
-}
+internal object ErrorTooBigException : MaeumGaGymTestException(TestErrorCode.ERROR_TOO_BIG)

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/exception/WakatimeDoesNotSavedException.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/exception/WakatimeDoesNotSavedException.kt
@@ -3,5 +3,4 @@ package com.info.maeumgagym.domain.wakatime.exception
 import com.info.maeumgagym.global.MaeumGaGymTestException
 import com.info.maeumgagym.global.TestErrorCode
 
-internal object WakatimeDoesNotSavedException : MaeumGaGymTestException(TestErrorCode.WAKATIME_DOES_NOT_SAVED) {
-}
+internal object WakatimeDoesNotSavedException : MaeumGaGymTestException(TestErrorCode.WAKATIME_DOES_NOT_SAVED)

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/exception/WakatimeDoesNotSavedException.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/exception/WakatimeDoesNotSavedException.kt
@@ -1,0 +1,7 @@
+package com.info.maeumgagym.domain.wakatime.exception
+
+import com.info.maeumgagym.global.MaeumGaGymTestException
+import com.info.maeumgagym.global.TestErrorCode
+
+internal object WakatimeDoesNotSavedException : MaeumGaGymTestException(TestErrorCode.WAKATIME_DOES_NOT_SAVED) {
+}

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/module/WakatimeTestModule.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/module/WakatimeTestModule.kt
@@ -35,7 +35,8 @@ internal object WakatimeTestModule {
             oauthId = oauthId,
             roles = roles,
             profileImage = profileImage,
-            wakaStartedAt = wakaStartedAt?.minusSeconds(10) ?: throw RuntimeException()
+            wakaStartedAt = wakaStartedAt?.minusSeconds(10) ?: throw RuntimeException(),
+            id = id
         )
 
     fun isSimilarWithAllowableErrorSize(a: Long, b: Long, allowableErrorSize: Long) {

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/module/WakatimeTestModule.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/module/WakatimeTestModule.kt
@@ -1,0 +1,45 @@
+package com.info.maeumgagym.domain.wakatime.module
+
+import com.info.maeumgagym.domain.user.entity.UserJpaEntity
+import com.info.maeumgagym.domain.wakatime.entity.WakaTimeJpaEntity
+import com.info.maeumgagym.domain.wakatime.exception.ErrorTooBigException
+import com.info.maeumgagym.domain.wakatime.repository.WakaTimeRepository
+import java.time.LocalDate
+
+internal object WakatimeTestModule {
+
+    const val WAKATIME_SECONDS = 30L
+
+    fun createTodayWakatime(user: UserJpaEntity): WakaTimeJpaEntity =
+        WakaTimeJpaEntity(
+            user = user,
+            waka = WAKATIME_SECONDS,
+            date = LocalDate.now(),
+            isNew = true
+        )
+
+    fun createYesterdayWakatime(user: UserJpaEntity): WakaTimeJpaEntity =
+        WakaTimeJpaEntity(
+            user = user,
+            waka = WAKATIME_SECONDS,
+            date = LocalDate.now().minusDays(1),
+            isNew = true
+        )
+
+    fun WakaTimeJpaEntity.saveInRepository(wakaTimeRepository: WakaTimeRepository): WakaTimeJpaEntity =
+        wakaTimeRepository.save(this)
+
+    fun UserJpaEntity.setWakaStartedAtToBefore10Seconds(): UserJpaEntity =
+        UserJpaEntity(
+            nickname = nickname,
+            oauthId = oauthId,
+            roles = roles,
+            profileImage = profileImage,
+            wakaStartedAt = wakaStartedAt?.minusSeconds(10) ?: throw RuntimeException()
+        )
+
+    fun isSimilarWithAllowableErrorSize(a: Long, b: Long, allowableErrorSize: Long) {
+        if (a - allowableErrorSize > b || a + allowableErrorSize < b)
+            throw ErrorTooBigException
+    }
+}

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/global/MaeumGaGymTestException.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/global/MaeumGaGymTestException.kt
@@ -1,0 +1,5 @@
+package com.info.maeumgagym.global
+
+abstract class MaeumGaGymTestException(
+    errorCode: TestErrorCode
+) : RuntimeException(errorCode.message)

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/global/MaeumGaGymTestException.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/global/MaeumGaGymTestException.kt
@@ -1,5 +1,5 @@
 package com.info.maeumgagym.global
 
-abstract class MaeumGaGymTestException(
+internal abstract class MaeumGaGymTestException(
     errorCode: TestErrorCode
 ) : RuntimeException(errorCode.message)

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/global/TestErrorCode.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/global/TestErrorCode.kt
@@ -1,0 +1,14 @@
+package com.info.maeumgagym.global
+
+import com.info.maeumgagym.common.exception.ErrorCode
+
+enum class TestErrorCode(
+    val message: String
+) {
+    // Wakatime
+    WAKATIME_DOES_NOT_SAVED("와카타임이 저장되지 않았습니다."),
+    ERROR_TOO_BIG("발생한 오차가 허용된 오차보다 큽니다."),
+
+    // Quote
+    MISMATCH_QUOTE_AND_QUOTER("명언과 화자가 어울리지 않습니다.")
+}

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/global/TestErrorCode.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/global/TestErrorCode.kt
@@ -1,8 +1,6 @@
 package com.info.maeumgagym.global
 
-import com.info.maeumgagym.common.exception.ErrorCode
-
-enum class TestErrorCode(
+internal enum class TestErrorCode(
     val message: String
 ) {
     // Wakatime

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/global/TestErrorCode.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/global/TestErrorCode.kt
@@ -10,5 +10,5 @@ enum class TestErrorCode(
     ERROR_TOO_BIG("발생한 오차가 허용된 오차보다 큽니다."),
 
     // Quote
-    MISMATCH_QUOTE_AND_QUOTER("명언과 화자가 어울리지 않습니다.")
+    MISMATCH_QUOTE_AND_QUOTER("명언과 화자가 설정된 것과 일치하지 않습니다.")
 }


### PR DESCRIPTION
- 와카타임 테스트 코드 작성
- 와카타임 테스트 모듈 생성
- 테스트 전용 예외 추가

빠트린 예외 상황이 있는지 확인해주세요.
user.saveInContext는 readCurrentUser의 알고리즘 변경으로 인해 매우 많이 사용되었습니다. 해당 관련해서 질문있으면 코멘트 남겨주세요.
JPA 영속성 관리와 관련한 오류가 있는지 확인해주세요.