### PR TITLE
📝 :: native query Repository 분할

### DIFF
--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pickle/PickleCommentPersistenceAdapter.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pickle/PickleCommentPersistenceAdapter.kt
@@ -8,6 +8,8 @@ import com.info.maeumgagym.pickle.port.out.ReadAllPickleCommentsByVideoIdPort
 import com.info.maeumgagym.pickle.port.out.ReadPickleCommentPort
 import com.info.maeumgagym.pickle.port.out.SavePickleCommentPort
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 
 @PersistenceAdapter
 internal class PickleCommentPersistenceAdapter(
@@ -15,8 +17,9 @@ internal class PickleCommentPersistenceAdapter(
     private val pickleCommentMapper: PickleCommentMapper
 ): SavePickleCommentPort, ReadPickleCommentPort, ReadAllPickleCommentsByVideoIdPort {
     override fun readPickleComment(pickleCommentId: Long): PickleComment? =
-        pickleCommentRepository.findByIdOrNull(pickleCommentId)?.let { pickleCommentMapper.toDomain(it) }
+        pickleCommentRepository.findById(pickleCommentId)?.let { pickleCommentMapper.toDomain(it) }
 
+    @Transactional(propagation = Propagation.MANDATORY)
     override fun savePickleComment(pickleComment: PickleComment): PickleComment =
         pickleCommentMapper.toDomain(pickleCommentRepository.save(pickleCommentMapper.toEntity(pickleComment)))
 

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pickle/PicklePersistenceAdapter.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pickle/PicklePersistenceAdapter.kt
@@ -6,6 +6,8 @@ import com.info.maeumgagym.domain.pickle.repository.PickleRepository
 import com.info.maeumgagym.pickle.model.Pickle
 import com.info.maeumgagym.pickle.port.out.*
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 
 @PersistenceAdapter
 internal class PicklePersistenceAdapter(
@@ -13,17 +15,19 @@ internal class PicklePersistenceAdapter(
     private val pickleMapper: PickleMapper
 ) : SavePicklePort, DeletePicklePort, ReadPickleByIdPort, ReadAllPicklesPort, ExistsPickleByIdPort {
 
+    @Transactional(propagation = Propagation.MANDATORY)
     override fun savePickle(pickle: Pickle): Pickle =
         pickleMapper.toDomain(
             pickleRepository.save(pickleMapper.toEntity(pickle))
         )
 
+    @Transactional(propagation = Propagation.MANDATORY)
     override fun deletePickle(pickle: Pickle) {
         pickleRepository.delete(pickleMapper.toEntity(pickle))
     }
 
     override fun readPickleById(id: String): Pickle? =
-        pickleRepository.findByIdOrNull(id)?.let {
+        pickleRepository.findByVideoId(id)?.let {
             pickleMapper.toDomain(it)
         }
 
@@ -33,5 +37,5 @@ internal class PicklePersistenceAdapter(
         }
 
     override fun existsPickleById(videoId: String): Boolean =
-        pickleRepository.findByIdOrNull(videoId)?.let { true } ?: false
+        pickleRepository.findByVideoId(videoId)?.let { true } ?: false
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pickle/PickleReplyPersistenceAdapter.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pickle/PickleReplyPersistenceAdapter.kt
@@ -7,17 +7,22 @@ import com.info.maeumgagym.pickle.model.PickleComment
 import com.info.maeumgagym.pickle.model.PickleReply
 import com.info.maeumgagym.pickle.port.out.ReadAllReplyByParentCommentPort
 import com.info.maeumgagym.pickle.port.out.SavePickleReplyCommentPort
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 
 @PersistenceAdapter
 internal class PickleReplyPersistenceAdapter(
     private val pickleReplyRepository: PickleReplyRepository,
     private val pickleCommentMapper: PickleCommentMapper
 ): SavePickleReplyCommentPort, ReadAllReplyByParentCommentPort {
-    override fun savePickleReplyComment(pickleReply: PickleReply): PickleReply =
-        pickleCommentMapper.toDomain(pickleReplyRepository.save(pickleCommentMapper.toEntity(pickleReply)))
 
-    override fun readAllPickleReplyByParentComment(parentComment: PickleComment): List<PickleReply> {
-        val pickleReplyList = pickleReplyRepository.findAllByParentComment(pickleCommentMapper.toEntity(parentComment))
-        return pickleReplyList.map { pickleCommentMapper.toDomain(it) }.toList()
-    }
+    @Transactional(propagation = Propagation.MANDATORY)
+    override fun savePickleReplyComment(pickleReply: PickleReply): PickleReply =
+        pickleCommentMapper.toDomain(
+            pickleReplyRepository.save(pickleCommentMapper.toEntity(pickleReply))
+        )
+
+    override fun readAllPickleReplyByParentComment(parentComment: PickleComment): List<PickleReply> =
+        pickleReplyRepository.findAllByParentComment(pickleCommentMapper.toEntity(parentComment))
+            .map { pickleCommentMapper.toDomain(it) }.toList()
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pickle/repository/PickleCommentMappedRepository.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pickle/repository/PickleCommentMappedRepository.kt
@@ -1,9 +1,8 @@
 package com.info.maeumgagym.domain.pickle.repository
 
 import com.info.maeumgagym.domain.pickle.entity.PickleCommentMappedEntity
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
+import org.springframework.data.repository.Repository
 
-@Repository
-interface PickleCommentMappedRepository: JpaRepository<PickleCommentMappedEntity, Long> {
+@org.springframework.stereotype.Repository
+interface PickleCommentMappedRepository: Repository<PickleCommentMappedEntity, Long> {
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pickle/repository/PickleCommentRepository.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pickle/repository/PickleCommentRepository.kt
@@ -1,10 +1,14 @@
 package com.info.maeumgagym.domain.pickle.repository
 
 import com.info.maeumgagym.domain.pickle.entity.PickleCommentJpaEntity
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
+import org.springframework.data.repository.Repository
 
-@Repository
-interface PickleCommentRepository : JpaRepository<PickleCommentJpaEntity, Long> {
+@org.springframework.stereotype.Repository
+interface PickleCommentRepository : Repository<PickleCommentJpaEntity, Long> {
+
+    fun save(entity: PickleCommentJpaEntity): PickleCommentJpaEntity
+
     fun findAllByVideoId(videoId: String): List<PickleCommentJpaEntity>
+
+    fun findById(id: Long): PickleCommentJpaEntity?
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pickle/repository/PickleLikeRepository.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pickle/repository/PickleLikeRepository.kt
@@ -1,8 +1,7 @@
 package com.info.maeumgagym.domain.pickle.repository
 
 import com.info.maeumgagym.domain.pickle.entity.PickleLikeJpaEntity
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
+import org.springframework.data.repository.Repository
 
-@Repository
-interface PickleLikeRepository : JpaRepository<PickleLikeJpaEntity, PickleLikeJpaEntity.IdClass>
+@org.springframework.stereotype.Repository
+interface PickleLikeRepository : Repository<PickleLikeJpaEntity, PickleLikeJpaEntity.IdClass>

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pickle/repository/PickleReplyRepository.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pickle/repository/PickleReplyRepository.kt
@@ -2,10 +2,12 @@ package com.info.maeumgagym.domain.pickle.repository
 
 import com.info.maeumgagym.domain.pickle.entity.PickleCommentJpaEntity
 import com.info.maeumgagym.domain.pickle.entity.PickleReplyJpaEntity
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
+import org.springframework.data.repository.Repository
 
-@Repository
-interface PickleReplyRepository : JpaRepository<PickleReplyJpaEntity, Long> {
+@org.springframework.stereotype.Repository
+interface PickleReplyRepository : Repository<PickleReplyJpaEntity, Long> {
+
     fun findAllByParentComment(pickleCommentJpaEntity: PickleCommentJpaEntity): List<PickleReplyJpaEntity>
+
+    fun save(entity: PickleReplyJpaEntity): PickleReplyJpaEntity
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pickle/repository/PickleRepository.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pickle/repository/PickleRepository.kt
@@ -1,10 +1,17 @@
 package com.info.maeumgagym.domain.pickle.repository
 
 import com.info.maeumgagym.domain.pickle.entity.PickleJpaEntity
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
+import org.springframework.data.repository.Repository
 
-@Repository
-interface PickleRepository : JpaRepository<PickleJpaEntity, String> {
+@org.springframework.stereotype.Repository
+interface PickleRepository : Repository<PickleJpaEntity, String> {
+
+    fun save(entity: PickleJpaEntity): PickleJpaEntity
+
+    fun delete(entity: PickleJpaEntity)
+
+    fun findByVideoId(id: String): PickleJpaEntity?
+
+    fun findAll(): List<PickleJpaEntity>
 }
 

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pose/PosePersistenceAdapter.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pose/PosePersistenceAdapter.kt
@@ -14,5 +14,8 @@ internal class PosePersistenceAdapter(
     private val poseMapper: PoseMapper
 ) : FindPoseByIdPort {
 
-    override fun findById(id: Long): Pose? = poseRepository.findByIdOrNull(id)?.let { poseMapper.toDomain(it) }
+    override fun findById(id: Long): Pose? =
+        poseRepository.findById(id)?.let {
+            poseMapper.toDomain(it)
+        }
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pose/repository/PoseRepository.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/pose/repository/PoseRepository.kt
@@ -1,8 +1,10 @@
 package com.info.maeumgagym.domain.pose.repository
 
 import com.info.maeumgagym.domain.pose.entity.PoseJpaEntity
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
+import org.springframework.data.repository.Repository
 
-@Repository
-interface PoseRepository : JpaRepository<PoseJpaEntity, Long?>
+@org.springframework.stereotype.Repository
+interface PoseRepository : Repository<PoseJpaEntity, Long?>{
+
+    fun findById(id: Long): PoseJpaEntity?
+}

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/routine/RoutinePersistenceAdapter.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/routine/RoutinePersistenceAdapter.kt
@@ -9,6 +9,7 @@ import com.info.maeumgagym.routine.port.out.ReadAllRoutineByUserIdPort
 import com.info.maeumgagym.routine.port.out.ReadRoutineByIdPort
 import com.info.maeumgagym.routine.port.out.SaveRoutinePort
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
@@ -18,6 +19,7 @@ internal class RoutinePersistenceAdapter(
     private val routineRepository: RoutineRepository
 ) : SaveRoutinePort, ReadAllRoutineByUserIdPort, DeleteRoutinePort, ReadRoutineByIdPort {
 
+    @Transactional(propagation = Propagation.MANDATORY)
     override fun saveRoutine(routine: Routine): Routine {
         val routineJpaEntity = routineRepository.save(routineMapper.toEntity(routine))
         return routineMapper.toDomain(routineJpaEntity)
@@ -28,9 +30,10 @@ internal class RoutinePersistenceAdapter(
         return routineEntityList.map { routineMapper.toDomain(it) }
     }
 
+    @Transactional(propagation = Propagation.MANDATORY)
     override fun deleteRoutine(routine: Routine) =
         routineRepository.delete(routineMapper.toEntity(routine))
 
     override fun readRoutineById(routineId: Long): Routine? =
-        routineRepository.findByIdOrNull(routineId)?.let { routineMapper.toDomain(it) }
+        routineRepository.findById(routineId)?.let { routineMapper.toDomain(it) }
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/routine/repository/RoutineRepository.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/routine/repository/RoutineRepository.kt
@@ -1,11 +1,17 @@
 package com.info.maeumgagym.domain.routine.repository
 
 import com.info.maeumgagym.domain.routine.entity.RoutineJpaEntity
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
+import org.springframework.data.repository.Repository
 import java.util.UUID
 
-@Repository
-interface RoutineRepository : JpaRepository<RoutineJpaEntity, Long> {
+@org.springframework.stereotype.Repository
+interface RoutineRepository : Repository<RoutineJpaEntity, Long> {
+
     fun findAllByUserId(userId: UUID): List<RoutineJpaEntity>
+
+    fun save(entity: RoutineJpaEntity): RoutineJpaEntity
+
+    fun delete(entity: RoutineJpaEntity)
+
+    fun findById(id: Long): RoutineJpaEntity?
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/user/DeletedAtPersistenceAdapter.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/user/DeletedAtPersistenceAdapter.kt
@@ -7,7 +7,8 @@ import com.info.maeumgagym.domain.user.repository.DeletedAtRepository
 import com.info.maeumgagym.user.model.DeletedAt
 import com.info.maeumgagym.user.port.out.FindDeletedAtByIdPort
 import com.info.maeumgagym.user.port.out.SaveDeletedAtPort
-import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.util.*
 
@@ -17,13 +18,17 @@ internal class DeletedAtPersistenceAdapter(
     private val deletedAtRepository: DeletedAtRepository
 ): SaveDeletedAtPort, FindDeletedAtByIdPort, DeleteDeletedAtPort {
 
+    @Transactional(propagation = Propagation.MANDATORY)
     override fun save(domain: DeletedAt): DeletedAt =
-        userMapper.toDomain(deletedAtRepository.save(userMapper.toEntity(domain)))
+        userMapper.toDomain(
+            deletedAtRepository.save(userMapper.toEntity(domain))
+        )
 
     override fun findDeletedAt(id: UUID): LocalDate? =
-        deletedAtRepository.findByIdOrNull(id)?.date
+        deletedAtRepository.findByUserId(id)?.date
 
+    @Transactional(propagation = Propagation.MANDATORY)
     override fun delete(userId: UUID) {
-        deletedAtRepository.deleteById(userId)
+        deletedAtRepository.deleteByUserId(userId)
     }
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/user/DeletedAtPersistenceAdapter.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/user/DeletedAtPersistenceAdapter.kt
@@ -24,11 +24,11 @@ internal class DeletedAtPersistenceAdapter(
             deletedAtRepository.save(userMapper.toEntity(domain))
         )
 
-    override fun findDeletedAt(id: UUID): LocalDate? =
+    override fun findDeletedAtById(id: UUID): LocalDate? =
         deletedAtRepository.findByUserId(id)?.date
 
     @Transactional(propagation = Propagation.MANDATORY)
-    override fun delete(userId: UUID) {
+    override fun deleteById(userId: UUID) {
         deletedAtRepository.deleteByUserId(userId)
     }
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/user/UserPersistenceAdapter.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/user/UserPersistenceAdapter.kt
@@ -47,9 +47,9 @@ internal class UserPersistenceAdapter(
         userRepository.delete(userMapper.toEntity(user))
     }
 
-    override fun existByNicknameOfWithdrawalSafe(nickName: String): Boolean =
-        userNativeRepository.findByNicknameOfWithdrawalSafe(nickName)?.let { true } ?: false
+    override fun existByNicknameOnWithdrawalSafe(nickName: String): Boolean =
+        userNativeRepository.findByNicknameOnWithdrawalSafe(nickName)?.let { true } ?: false
 
-    override fun existByOAuthIdOfWithdrawalSafe(oauthId: String): Boolean =
-        userNativeRepository.findByOauthIdOfWithdrawalSafe(oauthId)?.let { true } ?: false
+    override fun existUserByOAuthIdOnWithdrawalSafe(oauthId: String): Boolean =
+        userNativeRepository.findByOauthIdOnWithdrawalSafe(oauthId)?.let { true } ?: false
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/user/UserPersistenceAdapter.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/user/UserPersistenceAdapter.kt
@@ -2,17 +2,19 @@ package com.info.maeumgagym.domain.user
 
 import com.info.common.PersistenceAdapter
 import com.info.maeumgagym.domain.user.mapper.UserMapper
+import com.info.maeumgagym.domain.user.repository.UserNativeRepository
 import com.info.maeumgagym.domain.user.repository.UserRepository
 import com.info.maeumgagym.user.model.User
 import com.info.maeumgagym.user.port.out.*
-import org.springframework.data.repository.findByIdOrNull
-import java.math.BigInteger
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
 @PersistenceAdapter
 internal class UserPersistenceAdapter(
     private val userRepository: UserRepository,
-    private val userMapper: UserMapper
+    private val userMapper: UserMapper,
+    private val userNativeRepository: UserNativeRepository
 ) : FindUserByUUIDPort,
     SaveUserPort,
     FindUserByOAuthIdPort,
@@ -21,31 +23,33 @@ internal class UserPersistenceAdapter(
     ExistUserByOAuthIdPort,
     FindDeletedUserByIdPort {
 
-    override fun findByIdOrNullInNative(oauthId: String): User? =
-        userRepository.findDeletedUserByOauthIdInNative(oauthId)?.let { userMapper.toDomain(it) }
+    override fun findDeletedUserByOauthId(oauthId: String): User? =
+        userNativeRepository.findDeletedUserByOauthId(oauthId)?.let { userMapper.toDomain(it) }
 
 
     override fun findUserById(userId: UUID): User? =
-        userRepository.findByIdOrNull(userId)?.let { userMapper.toDomain(it) }
+        userRepository.findById(userId)?.let { userMapper.toDomain(it) }
 
     override fun existsUserByOAuthId(oauthId: String): Boolean =
         userRepository.findByOauthId(oauthId)?.let { true } ?: false
 
-    override fun saveUser(user: User): User {
-        val userJpaEntity = userRepository.save(userMapper.toEntity(user))
-        return userMapper.toDomain(userJpaEntity)
-    }
+    @Transactional(propagation = Propagation.MANDATORY)
+    override fun saveUser(user: User): User =
+        userMapper.toDomain(
+            userRepository.save(userMapper.toEntity(user))
+        )
 
     override fun findUserByOAuthId(oauthId: String): User? =
         userRepository.findByOauthId(oauthId)?.let { userMapper.toDomain(it) }
 
+    @Transactional(propagation = Propagation.MANDATORY)
     override fun deleteUser(user: User) {
         userRepository.delete(userMapper.toEntity(user))
     }
 
-    override fun existByNicknameInNative(nickName: String): Boolean =
-        userRepository.findByNicknameInNative(nickName)?.let { true } ?: false
+    override fun existByNicknameOfWithdrawalSafe(nickName: String): Boolean =
+        userNativeRepository.findByNicknameOfWithdrawalSafe(nickName)?.let { true } ?: false
 
-    override fun existByOAuthIdInNative(oauthId: String): Boolean =
-        userRepository.findByOauthIdInNative(oauthId)?.let { true } ?: false
+    override fun existByOAuthIdOfWithdrawalSafe(oauthId: String): Boolean =
+        userNativeRepository.findByOauthIdOfWithdrawalSafe(oauthId)?.let { true } ?: false
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/user/repository/DeletedAtRepository.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/user/repository/DeletedAtRepository.kt
@@ -1,10 +1,15 @@
 package com.info.maeumgagym.domain.user.repository
 
 import com.info.maeumgagym.domain.user.entity.DeletedAtJpaEntity
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
+import org.springframework.data.repository.Repository
 import java.util.*
 
-@Repository
-interface DeletedAtRepository : JpaRepository<DeletedAtJpaEntity, UUID> {
+@org.springframework.stereotype.Repository
+interface DeletedAtRepository : Repository<DeletedAtJpaEntity, UUID> {
+
+    fun save(entity: DeletedAtJpaEntity): DeletedAtJpaEntity
+
+    fun findByUserId(id: UUID): DeletedAtJpaEntity?
+
+    fun deleteByUserId(id: UUID)
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/user/repository/UserNativeRepository.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/user/repository/UserNativeRepository.kt
@@ -1,0 +1,45 @@
+package com.info.maeumgagym.domain.user.repository
+
+import com.info.maeumgagym.TableNames
+import com.info.maeumgagym.domain.user.entity.UserJpaEntity
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.Repository
+import org.springframework.data.repository.query.Param
+import java.util.*
+
+@org.springframework.stereotype.Repository
+interface UserNativeRepository: Repository<UserJpaEntity, UUID> {
+    @Query(
+        value = "SELECT * FROM ${TableNames.USER_TABLE} u WHERE u.nickname = :nickname limit 1",
+        nativeQuery = true
+    )
+    fun findByNicknameOfWithdrawalSafe(@Param("nickname") nickname: String): UserJpaEntity?
+
+    @Query(
+        value = "SELECT * FROM ${TableNames.USER_TABLE} u WHERE u.oauth_id = :oauthId limit 1",
+        nativeQuery = true
+    )
+    fun findByOauthIdOfWithdrawalSafe(@Param("oauthId") oauthId: String): UserJpaEntity?
+
+    @Query(
+        value = "SELECT * FROM ${TableNames.USER_TABLE} u WHERE u.oauth_id = :oauthId and u.is_deleted = true limit 1",
+        nativeQuery = true
+    )
+    fun findDeletedUserByOauthId(@Param("oauthId") oauthId: String): UserJpaEntity?
+
+    @Query(
+        value = "DELETE users, delete_at " +
+            "FROM ${TableNames.USER_TABLE} users " +
+            "JOIN ${TableNames.DELETED_AT_TABLE} delete_at ON users.id = delete_at.user_id " +
+            "WHERE users.is_deleted = true " +
+            "AND delete_at.date <= DATE_SUB(NOW(), INTERVAL 30 DAY)",
+        nativeQuery = true
+    )
+    fun deleteAllWithdrawalUserOneMonthAgo(): MutableList<UserJpaEntity>
+
+    @Query(
+        value = "SELECT * FROM ${TableNames.USER_TABLE} u WHERE u.waka_started_at IS NOT NULL",
+        nativeQuery = true
+    )
+    fun findAllByWakaStartedAtNotNullInNative(): MutableList<UserJpaEntity>
+}

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/user/repository/UserNativeRepository.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/user/repository/UserNativeRepository.kt
@@ -13,13 +13,13 @@ interface UserNativeRepository: Repository<UserJpaEntity, UUID> {
         value = "SELECT * FROM ${TableNames.USER_TABLE} u WHERE u.nickname = :nickname limit 1",
         nativeQuery = true
     )
-    fun findByNicknameOfWithdrawalSafe(@Param("nickname") nickname: String): UserJpaEntity?
+    fun findByNicknameOnWithdrawalSafe(@Param("nickname") nickname: String): UserJpaEntity?
 
     @Query(
         value = "SELECT * FROM ${TableNames.USER_TABLE} u WHERE u.oauth_id = :oauthId limit 1",
         nativeQuery = true
     )
-    fun findByOauthIdOfWithdrawalSafe(@Param("oauthId") oauthId: String): UserJpaEntity?
+    fun findByOauthIdOnWithdrawalSafe(@Param("oauthId") oauthId: String): UserJpaEntity?
 
     @Query(
         value = "SELECT * FROM ${TableNames.USER_TABLE} u WHERE u.oauth_id = :oauthId and u.is_deleted = true limit 1",
@@ -41,5 +41,5 @@ interface UserNativeRepository: Repository<UserJpaEntity, UUID> {
         value = "SELECT * FROM ${TableNames.USER_TABLE} u WHERE u.waka_started_at IS NOT NULL",
         nativeQuery = true
     )
-    fun findAllByWakaStartedAtNotNullInNative(): MutableList<UserJpaEntity>
+    fun findAllByWakaStartedAtNotNullOnWithdrawalSafe(): MutableList<UserJpaEntity>
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/user/repository/UserRepository.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/user/repository/UserRepository.kt
@@ -1,47 +1,18 @@
 package com.info.maeumgagym.domain.user.repository
 
-import com.info.maeumgagym.TableNames
 import com.info.maeumgagym.domain.user.entity.UserJpaEntity
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
-import java.util.UUID
+import org.springframework.data.repository.Repository
+import java.util.*
 
-interface UserRepository : JpaRepository<UserJpaEntity, UUID> {
+
+@org.springframework.stereotype.Repository
+interface UserRepository : Repository<UserJpaEntity, UUID> {
 
     fun findByOauthId(oauthId: String): UserJpaEntity?
 
-    @Query(
-        value = "SELECT * FROM ${TableNames.USER_TABLE} u WHERE u.nickname = :nickname limit 1",
-        nativeQuery = true
-    )
-    fun findByNicknameInNative(@Param("nickname") nickname: String): UserJpaEntity?
+    fun findById(id: UUID): UserJpaEntity?
 
-    @Query(
-        value = "SELECT * FROM ${TableNames.USER_TABLE} u WHERE u.oauth_id = :oauthId limit 1",
-        nativeQuery = true
-    )
-    fun findByOauthIdInNative(@Param("oauthId") oauthId: String): UserJpaEntity?
+    fun save(entity: UserJpaEntity): UserJpaEntity
 
-    @Query(
-        value = "SELECT * FROM ${TableNames.USER_TABLE} u WHERE u.oauth_id = :oauthId and u.is_deleted = true limit 1",
-        nativeQuery = true
-    )
-    fun findDeletedUserByOauthIdInNative(@Param("oauthId") oauthId: String): UserJpaEntity?
-
-    @Query(
-        value = "DELETE users, delete_at " +
-            "FROM ${TableNames.USER_TABLE} users " +
-            "JOIN ${TableNames.DELETED_AT_TABLE} delete_at ON users.id = delete_at.user_id " +
-            "WHERE users.is_deleted = true " +
-            "AND delete_at.date <= DATE_SUB(NOW(), INTERVAL 30 DAY)",
-        nativeQuery = true
-    )
-    fun deleteAllWithdrawalUserOneMonthAgo(): MutableList<UserJpaEntity>
-
-    @Query(
-        value = "SELECT * FROM ${TableNames.USER_TABLE} u WHERE u.waka_started_at IS NOT NULL",
-        nativeQuery = true
-    )
-    fun findAllByWakaStartedAtNotNullInNative(): MutableList<UserJpaEntity>
+    fun delete(entity: UserJpaEntity)
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/wakatime/WakaTimePersistenceAdapter.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/wakatime/WakaTimePersistenceAdapter.kt
@@ -8,6 +8,8 @@ import com.info.maeumgagym.user.model.User
 import com.info.maeumgagym.wakatime.model.WakaTime
 import com.info.maeumgagym.wakatime.port.out.*
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 
 @PersistenceAdapter
@@ -16,13 +18,14 @@ internal class WakaTimePersistenceAdapter(
     private val wakaTimeMapper: WakaTimeMapper
 ): SaveWakaTimePort, ReadWakaTimeFromUserAndDatePort {
 
+    @Transactional(propagation = Propagation.MANDATORY)
     override fun save(wakaTime: WakaTime): WakaTime =
         wakaTimeMapper.toDomain(
             wakaTimeRepository.save(wakaTimeMapper.toEntity(wakaTime))
         )
 
     override fun findByUserAndDate(user: User, date: LocalDate): WakaTime? =
-        wakaTimeRepository.findByIdOrNull(
+        wakaTimeRepository.findById(
             WakaTimeJpaEntity.IdClass(user.id, date)
         )?.let {
             wakaTimeMapper.toDomain(it)

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/wakatime/repository/WakaTimeRepository.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/wakatime/repository/WakaTimeRepository.kt
@@ -1,9 +1,12 @@
 package com.info.maeumgagym.domain.wakatime.repository
 
 import com.info.maeumgagym.domain.wakatime.entity.WakaTimeJpaEntity
-import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
+import org.springframework.data.repository.Repository
 
-@Repository
-interface WakaTimeRepository: JpaRepository<WakaTimeJpaEntity, WakaTimeJpaEntity.IdClass> {
+@org.springframework.stereotype.Repository
+interface WakaTimeRepository: Repository<WakaTimeJpaEntity, WakaTimeJpaEntity.IdClass> {
+
+    fun findById(id: WakaTimeJpaEntity.IdClass): WakaTimeJpaEntity?
+
+    fun save(entity: WakaTimeJpaEntity): WakaTimeJpaEntity
 }

--- a/maeumgagym-common/src/main/kotlin/com/info/common/UseCase.kt
+++ b/maeumgagym-common/src/main/kotlin/com/info/common/UseCase.kt
@@ -1,7 +1,6 @@
 package com.info.common
 
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)

--- a/maeumgagym-common/src/main/kotlin/com/info/common/UseCase.kt
+++ b/maeumgagym-common/src/main/kotlin/com/info/common/UseCase.kt
@@ -6,6 +6,5 @@ import org.springframework.transaction.annotation.Transactional
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 @MustBeDocumented
-@Transactional
 @Service
 annotation class UseCase()

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/port/out/DeleteDeletedAtPort.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/port/out/DeleteDeletedAtPort.kt
@@ -4,5 +4,5 @@ import java.util.*
 
 interface DeleteDeletedAtPort {
 
-    fun delete(userId: UUID)
+    fun deleteById(userId: UUID)
 }

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/AppleOAuthService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/AppleOAuthService.kt
@@ -43,13 +43,13 @@ internal class AppleOAuthService(
 
     override fun signUp(token: String, nickname: String) {
         // nickname 중복 확인
-        if (existUserByNicknamePort.existByNicknameOfWithdrawalSafe(nickname)) throw DuplicatedNicknameException
+        if (existUserByNicknamePort.existByNicknameOnWithdrawalSafe(nickname)) throw DuplicatedNicknameException
 
         // Apple id_token에서 subject값을 받아온다
         val sub = parseAppleTokenPort.parseIdToken(token).subject
 
         // 중복 유저 확인
-        if (existUserByOAuthIdPort.existByOAuthIdOfWithdrawalSafe(sub)) throw AlreadyExistUserException
+        if (existUserByOAuthIdPort.existUserByOAuthIdOnWithdrawalSafe(sub)) throw AlreadyExistUserException
 
         // 유저 생성
         saveUserPort.saveUser(

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/DuplicatedCheckService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/DuplicatedCheckService.kt
@@ -10,5 +10,5 @@ internal class DuplicatedCheckService(
 ) : DuplicatedNicknameCheckUseCase {
 
     override fun existByNickname(nickname: String): Boolean =
-        existUserByNicknamePort.existByNicknameInNative(nickname)
+        existUserByNicknamePort.existByNicknameOfWithdrawalSafe(nickname)
 }

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/DuplicatedCheckService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/DuplicatedCheckService.kt
@@ -10,5 +10,5 @@ internal class DuplicatedCheckService(
 ) : DuplicatedNicknameCheckUseCase {
 
     override fun existByNickname(nickname: String): Boolean =
-        existUserByNicknamePort.existByNicknameOfWithdrawalSafe(nickname)
+        existUserByNicknamePort.existByNicknameOnWithdrawalSafe(nickname)
 }

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/GoogleOAuthService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/GoogleOAuthService.kt
@@ -45,13 +45,13 @@ internal class GoogleOAuthService(
 
     override fun signup(accessToken: String, nickname: String) {
         // nickname 중복 확인
-        if (existUserByNicknamePort.existByNicknameOfWithdrawalSafe(nickname)) throw DuplicatedNicknameException
+        if (existUserByNicknamePort.existByNicknameOnWithdrawalSafe(nickname)) throw DuplicatedNicknameException
 
         // google access_token으로 profile 가져오기
         val profile = getGoogleInfoPort.getGoogleInfo(accessToken)
 
         // 중복 유저 확인
-        if (existUserByOAuthIdPort.existByOAuthIdOfWithdrawalSafe(profile.sub)) throw AlreadyExistUserException
+        if (existUserByOAuthIdPort.existUserByOAuthIdOnWithdrawalSafe(profile.sub)) throw AlreadyExistUserException
 
         // 유저 생성
         saveUserPort.saveUser(

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/GoogleOAuthService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/GoogleOAuthService.kt
@@ -14,8 +14,11 @@ import com.info.maeumgagym.auth.port.out.RevokeGoogleTokenPort
 import com.info.maeumgagym.user.model.Role
 import com.info.maeumgagym.user.model.User
 import com.info.maeumgagym.user.port.out.*
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
 
 @UseCase
+@Transactional(isolation = Isolation.SERIALIZABLE, rollbackFor = [Exception::class])
 internal class GoogleOAuthService(
     private val getGoogleInfoPort: GetGoogleInfoPort,
     private val saveUserPort: SaveUserPort,
@@ -42,13 +45,13 @@ internal class GoogleOAuthService(
 
     override fun signup(accessToken: String, nickname: String) {
         // nickname 중복 확인
-        if (existUserByNicknamePort.existByNicknameInNative(nickname)) throw DuplicatedNicknameException
+        if (existUserByNicknamePort.existByNicknameOfWithdrawalSafe(nickname)) throw DuplicatedNicknameException
 
         // google access_token으로 profile 가져오기
         val profile = getGoogleInfoPort.getGoogleInfo(accessToken)
 
         // 중복 유저 확인
-        if (existUserByOAuthIdPort.existByOAuthIdInNative(profile.sub)) throw AlreadyExistUserException
+        if (existUserByOAuthIdPort.existByOAuthIdOfWithdrawalSafe(profile.sub)) throw AlreadyExistUserException
 
         // 유저 생성
         saveUserPort.saveUser(

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/KakaoOAuthService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/KakaoOAuthService.kt
@@ -40,13 +40,13 @@ internal class KakaoOAuthService(
 
     override fun signup(accessToken: String, nickname: String) {
         // nickname 중복 확인
-        if (existUserByNicknamePort.existByNicknameOfWithdrawalSafe(nickname)) throw DuplicatedNicknameException
+        if (existUserByNicknamePort.existByNicknameOnWithdrawalSafe(nickname)) throw DuplicatedNicknameException
 
         // kakao access_token으로 유저 정보 가져오기
         val userInfo = getKakaoInfoPort.getInfo(accessToken)
 
         // 중복 유저 확인
-        if (existUserByOAuthIdPort.existByOAuthIdOfWithdrawalSafe(userInfo.id)) throw AlreadyExistUserException
+        if (existUserByOAuthIdPort.existUserByOAuthIdOnWithdrawalSafe(userInfo.id)) throw AlreadyExistUserException
 
         // 유저 생성
         saveUserPort.saveUser(

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/KakaoOAuthService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/KakaoOAuthService.kt
@@ -13,8 +13,11 @@ import com.info.maeumgagym.user.exception.DuplicatedNicknameException
 import com.info.maeumgagym.user.model.Role
 import com.info.maeumgagym.user.model.User
 import com.info.maeumgagym.user.port.out.*
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
 
 @UseCase
+@Transactional(isolation = Isolation.SERIALIZABLE, rollbackFor = [Exception::class])
 internal class KakaoOAuthService(
     private val getKakaoInfoPort: GetKakaoInfoPort,
     private val generateJwtPort: GenerateJwtPort,
@@ -37,13 +40,13 @@ internal class KakaoOAuthService(
 
     override fun signup(accessToken: String, nickname: String) {
         // nickname 중복 확인
-        if (existUserByNicknamePort.existByNicknameInNative(nickname)) throw DuplicatedNicknameException
+        if (existUserByNicknamePort.existByNicknameOfWithdrawalSafe(nickname)) throw DuplicatedNicknameException
 
         // kakao access_token으로 유저 정보 가져오기
         val userInfo = getKakaoInfoPort.getInfo(accessToken)
 
         // 중복 유저 확인
-        if (existUserByOAuthIdPort.existByOAuthIdInNative(userInfo.id)) throw AlreadyExistUserException
+        if (existUserByOAuthIdPort.existByOAuthIdOfWithdrawalSafe(userInfo.id)) throw AlreadyExistUserException
 
         // 유저 생성
         saveUserPort.saveUser(

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/ReissueService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/ReissueService.kt
@@ -4,8 +4,11 @@ import com.info.common.UseCase
 import com.info.maeumgagym.auth.dto.response.TokenResponse
 import com.info.maeumgagym.auth.port.`in`.ReissueUseCase
 import com.info.maeumgagym.auth.port.out.ReissuePort
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
 
 @UseCase
+@Transactional(isolation = Isolation.SERIALIZABLE, rollbackFor = [Exception::class])
 internal class ReissueService(
     private val reissuePort: ReissuePort
 ) : ReissueUseCase {

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/WithdrawalUserService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/WithdrawalUserService.kt
@@ -28,7 +28,7 @@ internal class WithdrawalUserService(
         * if (existsDeletedUserByIdPort.existsByIdInNative(user.oauthId)) throw AlreadyWithdrawalUserException
         */
 
-        // user soft delete
+        // user soft deleteById
         deleteUserPort.deleteUser(user)
 
         // 삭제된 유저 생명주기 관리용 테이블 생성

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/WithdrawalUserService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/WithdrawalUserService.kt
@@ -7,8 +7,11 @@ import com.info.maeumgagym.auth.port.out.RevokeTokensPort
 import com.info.maeumgagym.user.model.DeletedAt
 import com.info.maeumgagym.user.port.out.DeleteUserPort
 import com.info.maeumgagym.user.port.out.SaveDeletedAtPort
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
 
 @UseCase
+@Transactional(isolation = Isolation.SERIALIZABLE, rollbackFor = [Exception::class])
 internal class WithdrawalUserService(
     private val deleteUserPort: DeleteUserPort,
     private val readCurrentUserPort: ReadCurrentUserPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/CreatePickleCommentService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/CreatePickleCommentService.kt
@@ -8,8 +8,11 @@ import com.info.maeumgagym.pickle.model.PickleComment
 import com.info.maeumgagym.pickle.port.`in`.CreatePickleCommentUseCase
 import com.info.maeumgagym.pickle.port.out.ExistsPickleByIdPort
 import com.info.maeumgagym.pickle.port.out.SavePickleCommentPort
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
 
 @UseCase
+@Transactional(isolation = Isolation.SERIALIZABLE, rollbackFor = [Exception::class])
 internal class CreatePickleCommentService(
     private val savePickleCommentPort: SavePickleCommentPort,
     private val readCurrentUserPort: ReadCurrentUserPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/CreatePickleReplyCommentService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/CreatePickleReplyCommentService.kt
@@ -11,8 +11,11 @@ import com.info.maeumgagym.pickle.port.`in`.CreatePickleReplyCommentUseCase
 import com.info.maeumgagym.pickle.port.out.ExistsPickleByIdPort
 import com.info.maeumgagym.pickle.port.out.ReadPickleCommentPort
 import com.info.maeumgagym.pickle.port.out.SavePickleReplyCommentPort
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
 
 @UseCase
+@Transactional(isolation = Isolation.SERIALIZABLE, rollbackFor = [Exception::class])
 internal class CreatePickleReplyCommentService(
     private val savePickleReplyCommentPort: SavePickleReplyCommentPort,
     private val readCurrentUserPort: ReadCurrentUserPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/DeletePickleService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/DeletePickleService.kt
@@ -8,8 +8,11 @@ import com.info.maeumgagym.pickle.port.`in`.PickleDeleteUseCase
 import com.info.maeumgagym.pickle.port.out.DeletePicklePort
 import com.info.maeumgagym.pickle.port.out.FeignDeletePicklePort
 import com.info.maeumgagym.pickle.port.out.ReadPickleByIdPort
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
 
 @UseCase
+@Transactional(isolation = Isolation.SERIALIZABLE, rollbackFor = [Exception::class])
 internal class DeletePickleService(
     private val deletePicklePort: DeletePicklePort,
     private val feignDeletePicklePort: FeignDeletePicklePort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/UpdatePickleService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/UpdatePickleService.kt
@@ -9,8 +9,11 @@ import com.info.maeumgagym.pickle.model.Pickle
 import com.info.maeumgagym.pickle.port.`in`.UpdatePickleUseCase
 import com.info.maeumgagym.pickle.port.out.ReadPickleByIdPort
 import com.info.maeumgagym.pickle.port.out.SavePicklePort
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
 
 @UseCase
+@Transactional(isolation = Isolation.SERIALIZABLE, rollbackFor = [Exception::class])
 internal class UpdatePickleService(
     private val savePicklePort: SavePicklePort,
     private val readCurrentUserPort: ReadCurrentUserPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/UploadPickleService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/UploadPickleService.kt
@@ -8,8 +8,11 @@ import com.info.maeumgagym.pickle.model.Pickle
 import com.info.maeumgagym.pickle.port.`in`.PickleUploadUseCase
 import com.info.maeumgagym.pickle.port.out.ExistsPickleByIdPort
 import com.info.maeumgagym.pickle.port.out.SavePicklePort
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
 
 @UseCase
+@Transactional(isolation = Isolation.SERIALIZABLE, rollbackFor = [Exception::class])
 internal class UploadPickleService(
     private val savePicklePort: SavePicklePort,
     private val existsPickleByIdPort: ExistsPickleByIdPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/CreateRoutineService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/CreateRoutineService.kt
@@ -8,8 +8,11 @@ import com.info.maeumgagym.routine.model.Routine
 import com.info.maeumgagym.routine.model.RoutineStatusModel
 import com.info.maeumgagym.routine.port.`in`.CreateRoutineUseCase
 import com.info.maeumgagym.routine.port.out.SaveRoutinePort
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
 
 @UseCase
+@Transactional(isolation = Isolation.SERIALIZABLE, rollbackFor = [Exception::class])
 internal class CreateRoutineService(
     private val saveRoutinePort: SaveRoutinePort,
     private val readCurrentUserPort: ReadCurrentUserPort

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/CreateRoutineService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/CreateRoutineService.kt
@@ -17,6 +17,7 @@ internal class CreateRoutineService(
     private val saveRoutinePort: SaveRoutinePort,
     private val readCurrentUserPort: ReadCurrentUserPort
 ) : CreateRoutineUseCase {
+
     override fun createRoutine(req: CreateRoutineRequest) {
         // 운동 리스트가 비어있다면 -> 예외 처리
         if (req.exerciseInfoModelList.isEmpty()) throw ExerciseListCannotEmptyException

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/DeleteRoutineService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/DeleteRoutineService.kt
@@ -7,8 +7,11 @@ import com.info.maeumgagym.routine.exception.RoutineNotFoundException
 import com.info.maeumgagym.routine.port.`in`.DeleteRoutineUseCase
 import com.info.maeumgagym.routine.port.out.DeleteRoutinePort
 import com.info.maeumgagym.routine.port.out.ReadRoutineByIdPort
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
 
 @UseCase
+@Transactional(isolation = Isolation.SERIALIZABLE, rollbackFor = [Exception::class])
 internal class DeleteRoutineService(
     private val deleteRoutinePort: DeleteRoutinePort,
     private val readRoutineByIdPort: ReadRoutineByIdPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/UpdateRoutineService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/UpdateRoutineService.kt
@@ -10,8 +10,11 @@ import com.info.maeumgagym.routine.model.RoutineStatusModel
 import com.info.maeumgagym.routine.port.`in`.UpdateRoutineUseCase
 import com.info.maeumgagym.routine.port.out.ReadRoutineByIdPort
 import com.info.maeumgagym.routine.port.out.SaveRoutinePort
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
 
 @UseCase
+@Transactional(isolation = Isolation.SERIALIZABLE, rollbackFor = [Exception::class])
 internal class UpdateRoutineService(
     private val readRoutineByIdPort: ReadRoutineByIdPort,
     private val readCurrentUserPort: ReadCurrentUserPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/user/port/out/ExistUserByNicknamePort.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/user/port/out/ExistUserByNicknamePort.kt
@@ -2,5 +2,5 @@ package com.info.maeumgagym.user.port.out
 
 interface ExistUserByNicknamePort {
 
-    fun existByNicknameInNative(nickName: String): Boolean
+    fun existByNicknameOfWithdrawalSafe(nickName: String): Boolean
 }

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/user/port/out/ExistUserByNicknamePort.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/user/port/out/ExistUserByNicknamePort.kt
@@ -2,5 +2,5 @@ package com.info.maeumgagym.user.port.out
 
 interface ExistUserByNicknamePort {
 
-    fun existByNicknameOfWithdrawalSafe(nickName: String): Boolean
+    fun existByNicknameOnWithdrawalSafe(nickName: String): Boolean
 }

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/user/port/out/ExistUserByOAuthIdPort.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/user/port/out/ExistUserByOAuthIdPort.kt
@@ -1,7 +1,7 @@
 package com.info.maeumgagym.user.port.out
 
 interface ExistUserByOAuthIdPort {
-    fun existByOAuthIdInNative(oauthId: String): Boolean
+    fun existByOAuthIdOfWithdrawalSafe(oauthId: String): Boolean
 
     fun existsUserByOAuthId(oauthId: String): Boolean
 }

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/user/port/out/ExistUserByOAuthIdPort.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/user/port/out/ExistUserByOAuthIdPort.kt
@@ -1,7 +1,8 @@
 package com.info.maeumgagym.user.port.out
 
 interface ExistUserByOAuthIdPort {
-    fun existByOAuthIdOfWithdrawalSafe(oauthId: String): Boolean
+
+    fun existUserByOAuthIdOnWithdrawalSafe(oauthId: String): Boolean
 
     fun existsUserByOAuthId(oauthId: String): Boolean
 }

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/user/port/out/FindDeletedAtByIdPort.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/user/port/out/FindDeletedAtByIdPort.kt
@@ -5,5 +5,5 @@ import java.util.*
 
 interface FindDeletedAtByIdPort {
 
-    fun findDeletedAt(id: UUID): LocalDate?
+    fun findDeletedAtById(id: UUID): LocalDate?
 }

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/user/port/out/FindDeletedUserByIdPort.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/user/port/out/FindDeletedUserByIdPort.kt
@@ -4,5 +4,5 @@ import com.info.maeumgagym.user.model.User
 
 interface FindDeletedUserByIdPort {
 
-    fun findByIdOrNullInNative(oauthId: String): User?
+    fun findDeletedUserByOauthId(oauthId: String): User?
 }

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/wakatime/service/EndWakatimeService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/wakatime/service/EndWakatimeService.kt
@@ -12,7 +12,6 @@ import com.info.maeumgagym.wakatime.port.out.SaveWakaTimePort
 import org.springframework.transaction.annotation.Isolation
 import org.springframework.transaction.annotation.Transactional
 import java.time.Duration
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 @UseCase
@@ -31,10 +30,10 @@ internal class EndWakatimeService(
         // 와카타임 시작 시간 불러오기
         val wakaStarted = user.wakaStartedAt ?: throw WakaStartedNotYetException
 
-        // 와카타임 구하기
-        val seconds = Duration.between(wakaStarted, LocalDateTime.now()).seconds
+        val now = LocalDateTime.now()
 
-        val now = LocalDate.now()
+        // 와카타임 구하기
+        val seconds = Duration.between(wakaStarted, now).seconds
 
         // 와카타임 시작시간 초기화
         user.run {
@@ -51,8 +50,10 @@ internal class EndWakatimeService(
             )
         }
 
+        val date = now.toLocalDate()
+
         // 먼저 생성한 와카타임 있는지 확인
-        val wakaTime = readWakaTimeFromUserAndDatePort.findByUserAndDate(user, now)
+        val wakaTime = readWakaTimeFromUserAndDatePort.findByUserAndDate(user, date)
             ?.let {
                 // 있으면 waka += seconds
                 WakaTime(
@@ -65,7 +66,7 @@ internal class EndWakatimeService(
             // 없으면 waka = seconds
             user = user,
             waka = seconds,
-            date = now
+            date = date
         )
 
         // wakatime save

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/wakatime/service/EndWakatimeService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/wakatime/service/EndWakatimeService.kt
@@ -9,11 +9,14 @@ import com.info.maeumgagym.wakatime.model.WakaTime
 import com.info.maeumgagym.wakatime.port.`in`.EndWakatimeUseCase
 import com.info.maeumgagym.wakatime.port.out.ReadWakaTimeFromUserAndDatePort
 import com.info.maeumgagym.wakatime.port.out.SaveWakaTimePort
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 @UseCase
+@Transactional(isolation = Isolation.SERIALIZABLE, rollbackFor = [Exception::class])
 internal class EndWakatimeService(
     private val readCurrentUserPort: ReadCurrentUserPort,
     private val readWakaTimeFromUserAndDatePort: ReadWakaTimeFromUserAndDatePort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/wakatime/service/StartWakatimeService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/wakatime/service/StartWakatimeService.kt
@@ -6,9 +6,12 @@ import com.info.maeumgagym.user.model.User
 import com.info.maeumgagym.user.port.out.SaveUserPort
 import com.info.maeumgagym.wakatime.exception.AlreadyWakaStartedException
 import com.info.maeumgagym.wakatime.port.`in`.StartWakatimeUseCase
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 @UseCase
+@Transactional(isolation = Isolation.SERIALIZABLE, rollbackFor = [Exception::class])
 internal class StartWakatimeService(
     private val readCurrentUserPort: ReadCurrentUserPort,
     private val saveUserPort: SaveUserPort

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/adapter/auth/RecoveryAdapter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/adapter/auth/RecoveryAdapter.kt
@@ -17,7 +17,7 @@ internal class RecoveryAdapter(
 
     override fun recovery(oauthId: String) {
         // 해딩 유저를 삭제된 유저들 중에서 확인
-        val deletedUser = findDeletedUserByIdPort.findByIdOrNullInNative(oauthId) ?: throw UserNotFoundException
+        val deletedUser = findDeletedUserByIdPort.findDeletedUserByOauthId(oauthId) ?: throw UserNotFoundException
 
         // 유저의 소프트 딜리트 변경
         deletedUser.apply {

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/adapter/auth/RecoveryAdapter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/adapter/auth/RecoveryAdapter.kt
@@ -34,6 +34,6 @@ internal class RecoveryAdapter(
         }
 
         // 삭제된 유저 생명 주기 테이블 삭제
-        deleteDeletedAtPort.delete(deletedUser.id)
+        deleteDeletedAtPort.deleteById(deletedUser.id)
     }
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/scheduler/UserScheduler.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/scheduler/UserScheduler.kt
@@ -14,7 +14,7 @@ class UserScheduler(
     // 매일 3시 0분 0초에 작동
     @Scheduled(cron = "0 0 3 * * ?", zone = "Asia/Seoul")
     fun deleteAtOneMonthAgoUserClear() {
-        // 탈퇴 후 30일 지난 유저 모두 불러와서 hard delete
+        // 탈퇴 후 30일 지난 유저 모두 불러와서 hard deleteById
         userNativeRepository.deleteAllWithdrawalUserOneMonthAgo()
     }
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/scheduler/UserScheduler.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/scheduler/UserScheduler.kt
@@ -1,6 +1,6 @@
 package com.info.maeumgagym.scheduler
 
-import com.info.maeumgagym.domain.user.repository.UserRepository
+import com.info.maeumgagym.domain.user.repository.UserNativeRepository
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -8,13 +8,13 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional
 class UserScheduler(
-    private val userRepository: UserRepository
+    private val userNativeRepository: UserNativeRepository
 ) {
 
     // 매일 3시 0분 0초에 작동
     @Scheduled(cron = "0 0 3 * * ?", zone = "Asia/Seoul")
     fun deleteAtOneMonthAgoUserClear() {
         // 탈퇴 후 30일 지난 유저 모두 불러와서 hard delete
-        userRepository.deleteAllWithdrawalUserOneMonthAgo()
+        userNativeRepository.deleteAllWithdrawalUserOneMonthAgo()
     }
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/scheduler/WakaTimeScheduler.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/scheduler/WakaTimeScheduler.kt
@@ -35,13 +35,16 @@ class WakaTimeScheduler(
         var seconds: Long
 
         // 와카타임을 시작하고 종료하지 않은 모든 유저 불러오기
-        userNativeRepository.findAllByWakaStartedAtNotNullInNative().forEach { user ->
+        userNativeRepository.findAllByWakaStartedAtNotNullInNative().forEach { u ->
+
+            val user = userMapper.toDomain(u)
+
             // 와카타임 시작 시간 ~ 지금까지의 초
-            seconds = Duration.between(userMapper.toDomain(user).wakaStartedAt, now).seconds
+            seconds = Duration.between(user.wakaStartedAt, now).seconds
 
             saveWakaTimePort.save(
                 // 먼저 생성한 와카타임 있는지 확인
-                readWakaTimeFromUserAndDatePort.findByUserAndDate(userMapper.toDomain(user), yesterday)
+                readWakaTimeFromUserAndDatePort.findByUserAndDate(user, yesterday)
                     ?.let {
                         // 있으면 waka += seconds
                         WakaTime(
@@ -52,7 +55,7 @@ class WakaTimeScheduler(
                         )
                     } ?: WakaTime(
                     // 없으면 waka = seconds
-                    user = userMapper.toDomain(user),
+                    user = user,
                     waka = seconds,
                     date = yesterday
                 ))

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/scheduler/WakaTimeScheduler.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/scheduler/WakaTimeScheduler.kt
@@ -35,7 +35,7 @@ class WakaTimeScheduler(
         var seconds: Long
 
         // 와카타임을 시작하고 종료하지 않은 모든 유저 불러오기
-        userNativeRepository.findAllByWakaStartedAtNotNullInNative().forEach { u ->
+        userNativeRepository.findAllByWakaStartedAtNotNullOnWithdrawalSafe().forEach { u ->
 
             val user = userMapper.toDomain(u)
 
@@ -60,20 +60,36 @@ class WakaTimeScheduler(
                     date = yesterday
                 ))
 
-            // 와카타임 재시작
-            userRepository.save(
-                user.run {
-                    UserJpaEntity(
-                        nickname = nickname,
-                        oauthId = oauthId,
-                        roles = roles,
-                        profileImage = profileImage,
-                        wakaStartedAt = now,
-                        isDelete = isDeleted,
-                        id = id
-                    )
-                }
-            )
+            if (user.isDeleted) {
+                userRepository.save(
+                    user.run {
+                        UserJpaEntity(
+                            nickname = nickname,
+                            oauthId = oauthId,
+                            roles = roles,
+                            profileImage = profileImage,
+                            wakaStartedAt = null,
+                            isDelete = isDeleted,
+                            id = id
+                        )
+                    }
+                )
+            } else {
+                // 와카타임 재시작
+                userRepository.save(
+                    user.run {
+                        UserJpaEntity(
+                            nickname = nickname,
+                            oauthId = oauthId,
+                            roles = roles,
+                            profileImage = profileImage,
+                            wakaStartedAt = now,
+                            isDelete = isDeleted,
+                            id = id
+                        )
+                    }
+                )
+            }
         }
     }
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/scheduler/WakaTimeScheduler.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/scheduler/WakaTimeScheduler.kt
@@ -2,6 +2,7 @@ package com.info.maeumgagym.scheduler
 
 import com.info.maeumgagym.domain.user.entity.UserJpaEntity
 import com.info.maeumgagym.domain.user.mapper.UserMapper
+import com.info.maeumgagym.domain.user.repository.UserNativeRepository
 import com.info.maeumgagym.domain.user.repository.UserRepository
 import com.info.maeumgagym.wakatime.model.WakaTime
 import com.info.maeumgagym.wakatime.port.out.ReadWakaTimeFromUserAndDatePort
@@ -18,6 +19,7 @@ import java.time.LocalDateTime
 @Service
 class WakaTimeScheduler(
     private val userRepository: UserRepository,
+    private val userNativeRepository: UserNativeRepository,
     private val userMapper: UserMapper,
     private val saveWakaTimePort: SaveWakaTimePort,
     private val readWakaTimeFromUserAndDatePort: ReadWakaTimeFromUserAndDatePort
@@ -33,7 +35,7 @@ class WakaTimeScheduler(
         var seconds: Long
 
         // 와카타임을 시작하고 종료하지 않은 모든 유저 불러오기
-        userRepository.findAllByWakaStartedAtNotNullInNative().forEach { user ->
+        userNativeRepository.findAllByWakaStartedAtNotNullInNative().forEach { user ->
             // 와카타임 시작 시간 ~ 지금까지의 초
             seconds = Duration.between(userMapper.toDomain(user).wakaStartedAt, now).seconds
 

--- a/maeumgagym-infrastructure/src/main/resources/application.yml
+++ b/maeumgagym-infrastructure/src/main/resources/application.yml
@@ -20,6 +20,7 @@ spring:
                 format_sql: false
                 show_sql: true
                 use_sql_comments: false
+                dialect: org.hibernate.dialect.MySQL5InnoDBDialect
             open-in-view: false
 
 # server
@@ -38,6 +39,8 @@ server:
 logging:
     level:
         root: info
+        org.hibernate.sql: debug
+        org.hibernate.type: trace
 
 jwt:
     secretKey: ${JWT_SECRET_KEY}

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/routine/DeleteRoutineServiceTests.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/routine/DeleteRoutineServiceTests.kt
@@ -44,7 +44,7 @@ class DeleteRoutineServiceTests @Autowired constructor(
         Assertions.assertDoesNotThrow {
             deleteRoutineUseCase.deleteRoutine(routine.id!!)
         }
-        Assertions.assertNull(routineRepository.findByIdOrNull(routine.id!!))
+        Assertions.assertNull(routineRepository.findById(routine.id!!))
     }
 
     @Test
@@ -53,12 +53,12 @@ class DeleteRoutineServiceTests @Autowired constructor(
         Assertions.assertThrows(PermissionDeniedException::class.java) {
             deleteRoutineUseCase.deleteRoutine(routine.id!!)
         }
-        Assertions.assertNotNull(routineRepository.findByIdOrNull(routine.id!!))
+        Assertions.assertNotNull(routineRepository.findById(routine.id!!))
     }
 
     @Test
     fun deleteNonExistentRoutine() {
-        routineRepository.deleteById(routine.id!!)
+        routineRepository.delete(routine)
         Assertions.assertThrows(RoutineNotFoundException::class.java) {
             deleteRoutineUseCase.deleteRoutine(routine.id!!)
         }

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/routine/UpdateRoutineServiceTests.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/routine/UpdateRoutineServiceTests.kt
@@ -45,7 +45,7 @@ class UpdateRoutineServiceTests @Autowired constructor(
         entityManager.detach(routine)
         val request = RoutineTestModule.getUpdateRoutineRequest(routine)
         updateRoutineUseCase.updateRoutine(request, routine.id!!)
-        Assertions.assertNotEquals(routine, routineRepository.findByIdOrNull(routine.id!!))
+        Assertions.assertNotEquals(routine, routineRepository.findById(routine.id!!))
     }
 
     @Test
@@ -61,7 +61,7 @@ class UpdateRoutineServiceTests @Autowired constructor(
 
     @Test
     fun updateNonExistentRoutine() {
-        routineRepository.deleteById(routine.id!!)
+        routineRepository.delete(routine)
         Assertions.assertThrows(RoutineNotFoundException::class.java) {
             updateRoutineUseCase.updateRoutine(
                 RoutineTestModule.getUpdateRoutineRequest(routine),

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/user/WithdrawalUserServiceTests.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/user/WithdrawalUserServiceTests.kt
@@ -44,7 +44,7 @@ class WithdrawalUserServiceTests @Autowired constructor(
         Assertions.assertDoesNotThrow {
             withdrawalUserUseCase.withdrawal()
         }
-        Assertions.assertNull(userRepository.findByIdOrNull(user.id!!))
-        Assertions.assertNotNull(deletedAtRepository.findByIdOrNull(user.id!!))
+        Assertions.assertNull(userRepository.findById(user.id!!))
+        Assertions.assertNotNull(deletedAtRepository.findByUserId(user.id!!))
     }
 }

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/WakatimeTests.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/wakatime/WakatimeTests.kt
@@ -101,7 +101,7 @@ class WakatimeTests @Autowired constructor(
         Assertions.assertDoesNotThrow {
             WakatimeTestModule.isSimilarWithAllowableErrorSize(
                 a = 10,
-                b = wakaTimeRepository.findByIdOrNull(
+                b = wakaTimeRepository.findById(
                     WakaTimeJpaEntity.IdClass(user.id!!, LocalDate.now())
                 )?.waka ?: throw WakatimeDoesNotSavedException,
                 allowableErrorSize = 2
@@ -135,7 +135,7 @@ class WakatimeTests @Autowired constructor(
         Assertions.assertDoesNotThrow {
             WakatimeTestModule.isSimilarWithAllowableErrorSize(
                 a = 20,
-                b = wakaTimeRepository.findByIdOrNull(
+                b = wakaTimeRepository.findById(
                     WakaTimeJpaEntity.IdClass(user.id!!, LocalDate.now())
                 )?.waka ?: throw WakatimeDoesNotSavedException,
                 allowableErrorSize = 3
@@ -175,7 +175,7 @@ class WakatimeTests @Autowired constructor(
         Assertions.assertDoesNotThrow {
             WakatimeTestModule.isSimilarWithAllowableErrorSize(
                 a = 10,
-                b = wakaTimeRepository.findByIdOrNull(
+                b = wakaTimeRepository.findById(
                     WakaTimeJpaEntity.IdClass(user.id!!, LocalDate.now().minusDays(1))
                 )?.waka ?: throw WakatimeDoesNotSavedException,
                 allowableErrorSize = 2
@@ -209,7 +209,7 @@ class WakatimeTests @Autowired constructor(
         Assertions.assertDoesNotThrow {
             WakatimeTestModule.isSimilarWithAllowableErrorSize(
                 a = 10,
-                b = wakaTimeRepository.findByIdOrNull(
+                b = wakaTimeRepository.findById(
                     WakaTimeJpaEntity.IdClass(user.id!!, LocalDate.now().minusDays(1))
                 )?.waka ?: throw WakatimeDoesNotSavedException,
                 allowableErrorSize = 2
@@ -264,7 +264,7 @@ class WakatimeTests @Autowired constructor(
         Assertions.assertDoesNotThrow {
             WakatimeTestModule.isSimilarWithAllowableErrorSize(
                 a = 10,
-                b = wakaTimeRepository.findByIdOrNull(
+                b = wakaTimeRepository.findById(
                     WakaTimeJpaEntity.IdClass(user.id!!, LocalDate.now())
                 )?.waka ?: throw WakatimeDoesNotSavedException,
                 allowableErrorSize = 2


### PR DESCRIPTION
• @UseCase에 Transaction책임 제거
• Service Class에 Transactional 커스텀
• native query repository 분할
• PersistenceAdapter에서 부모 Transaction 강제성 부여