### PR TITLE
✨ :: 걸음수 생성, 수정 API 구현

### DIFF
--- a/maeumgagym-application/build.gradle.kts
+++ b/maeumgagym-application/build.gradle.kts
@@ -22,6 +22,9 @@ dependencies {
     implementation("com.querydsl:querydsl-jpa:${PluginVersions.QUERY_DSL}")
     kapt("com.querydsl:querydsl-apt:${PluginVersions.QUERY_DSL}:jpa")
     kapt("org.springframework.boot:spring-boot-configuration-processor")
+
+    // redis
+    implementation(Dependencies.REDIS)
 }
 
 allOpen {

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/TableNames.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/TableNames.kt
@@ -32,4 +32,6 @@ object TableNames {
     const val PICKLE_TAG_INDEX = "${INDEX_PREFIX}pickle_tag"
 
     const val PICKLE_LIKE_INDEX = "${INDEX_PREFIX}pickle_like"
+
+    const val REDIS_STEP_TABLE = "${TABLE_PREFIX}step"
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/step/StepPersistenceAdapter.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/step/StepPersistenceAdapter.kt
@@ -11,7 +11,7 @@ import com.info.maeumgagym.step.port.out.SaveStepPort
 internal class StepPersistenceAdapter(
     private val stepRepository: StepRepository,
     private val stepMapper: StepMapper
-): SaveStepPort, ReadStepPort {
+) : SaveStepPort, ReadStepPort {
     override fun readStep(userId: String): Step? = stepRepository.findById(userId)?.let { stepMapper.toDomain(it) }
 
     override fun saveStep(step: Step): Step = stepMapper.toDomain(stepRepository.save(stepMapper.toEntity(step)))

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/step/StepPersistenceAdapter.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/step/StepPersistenceAdapter.kt
@@ -1,0 +1,18 @@
+package com.info.maeumgagym.domain.step
+
+import com.info.common.PersistenceAdapter
+import com.info.maeumgagym.domain.step.mapper.StepMapper
+import com.info.maeumgagym.domain.step.repository.StepRepository
+import com.info.maeumgagym.step.model.Step
+import com.info.maeumgagym.step.port.out.ReadStepPort
+import com.info.maeumgagym.step.port.out.SaveStepPort
+
+@PersistenceAdapter
+internal class StepPersistenceAdapter(
+    private val stepRepository: StepRepository,
+    private val stepMapper: StepMapper
+): SaveStepPort, ReadStepPort {
+    override fun readStep(userId: String): Step? = stepRepository.findById(userId)?.let { stepMapper.toDomain(it) }
+
+    override fun saveStep(step: Step): Step = stepMapper.toDomain(stepRepository.save(stepMapper.toEntity(step)))
+}

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/step/StepPersistenceAdapter.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/step/StepPersistenceAdapter.kt
@@ -6,13 +6,20 @@ import com.info.maeumgagym.domain.step.repository.StepRepository
 import com.info.maeumgagym.step.model.Step
 import com.info.maeumgagym.step.port.out.ReadStepPort
 import com.info.maeumgagym.step.port.out.SaveStepPort
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 
 @PersistenceAdapter
 internal class StepPersistenceAdapter(
     private val stepRepository: StepRepository,
     private val stepMapper: StepMapper
 ) : SaveStepPort, ReadStepPort {
-    override fun readStep(userId: String): Step? = stepRepository.findById(userId)?.let { stepMapper.toDomain(it) }
+    override fun readByUserOauthId(oauthId: String): Step? = stepRepository.findById(oauthId)?.let {
+        stepMapper.toDomain(
+            it
+        )
+    }
 
-    override fun saveStep(step: Step): Step = stepMapper.toDomain(stepRepository.save(stepMapper.toEntity(step)))
+    @Transactional(propagation = Propagation.MANDATORY)
+    override fun save(step: Step): Step = stepMapper.toDomain(stepRepository.save(stepMapper.toEntity(step)))
 }

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/step/StepPersistenceAdapter.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/step/StepPersistenceAdapter.kt
@@ -14,11 +14,8 @@ internal class StepPersistenceAdapter(
     private val stepRepository: StepRepository,
     private val stepMapper: StepMapper
 ) : SaveStepPort, ReadStepPort {
-    override fun readByUserOauthId(oauthId: String): Step? = stepRepository.findById(oauthId)?.let {
-        stepMapper.toDomain(
-            it
-        )
-    }
+    override fun readByUserOauthId(oauthId: String): Step? =
+        stepRepository.findById(oauthId)?.let { stepMapper.toDomain(it) }
 
     @Transactional(propagation = Propagation.MANDATORY)
     override fun save(step: Step): Step = stepMapper.toDomain(stepRepository.save(stepMapper.toEntity(step)))

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/step/entity/StepRedisEntity.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/step/entity/StepRedisEntity.kt
@@ -1,0 +1,26 @@
+package com.info.maeumgagym.domain.step.entity
+
+import com.info.maeumgagym.TableNames
+import org.springframework.data.annotation.Id
+import org.springframework.data.redis.core.RedisHash
+import org.springframework.data.redis.core.TimeToLive
+import org.springframework.data.redis.core.index.Indexed
+
+@RedisHash(value = TableNames.REDIS_STEP_TABLE)
+class StepRedisEntity(
+    id: String,
+    numberOfSteps: Int,
+    ttl: Long
+) {
+    @Id
+    var id: String = id
+        protected set
+
+    @Indexed
+    var numberOfSteps: Int = numberOfSteps
+        protected set
+
+    @TimeToLive
+    var ttl: Long = ttl
+        protected set
+}

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/step/entity/StepRedisEntity.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/step/entity/StepRedisEntity.kt
@@ -4,7 +4,6 @@ import com.info.maeumgagym.TableNames
 import org.springframework.data.annotation.Id
 import org.springframework.data.redis.core.RedisHash
 import org.springframework.data.redis.core.TimeToLive
-import org.springframework.data.redis.core.index.Indexed
 
 @RedisHash(value = TableNames.REDIS_STEP_TABLE)
 class StepRedisEntity(
@@ -16,7 +15,6 @@ class StepRedisEntity(
     var id: String = id
         protected set
 
-    @Indexed
     var numberOfSteps: Int = numberOfSteps
         protected set
 

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/step/mapper/StepMapper.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/step/mapper/StepMapper.kt
@@ -1,0 +1,24 @@
+package com.info.maeumgagym.domain.step.mapper
+
+import com.info.maeumgagym.domain.step.entity.StepRedisEntity
+import com.info.maeumgagym.step.model.Step
+import org.springframework.stereotype.Component
+
+@Component
+class StepMapper {
+    fun toEntity(domain: Step): StepRedisEntity = domain.run {
+        StepRedisEntity(
+            id = id,
+            numberOfSteps = numberOfSteps,
+            ttl = ttl
+        )
+    }
+
+    fun toDomain(entity: StepRedisEntity): Step = entity.run {
+        Step(
+            id = id,
+            numberOfSteps = numberOfSteps,
+            ttl = ttl
+        )
+    }
+}

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/step/repository/StepRepository.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/step/repository/StepRepository.kt
@@ -1,0 +1,10 @@
+package com.info.maeumgagym.domain.step.repository
+
+import com.info.maeumgagym.domain.step.entity.StepRedisEntity
+import org.springframework.data.repository.Repository
+@org.springframework.stereotype.Repository
+interface StepRepository : Repository<StepRedisEntity, String> {
+    fun save(entity: StepRedisEntity): StepRedisEntity
+
+    fun findById(id: String): StepRedisEntity?
+}

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/common/exception/ErrorCode.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/common/exception/ErrorCode.kt
@@ -33,6 +33,7 @@ enum class ErrorCode(
     PICKLE_NOT_FOUND(404, "Pickle Not Found"),
     PICKLE_COMMENT_NOT_FOUND(404, "Pickle Comment Not Found"),
     PICKLE_REPLY_NOT_FOUND(404, "Pickle Reply Not Found"),
+    STEP_NOT_FOUND(404, "Step Not Found"),
 
     // Bad Request
     FILE_TYPE_MISMATCHED(400, "File Type Mismatched"),
@@ -47,6 +48,7 @@ enum class ErrorCode(
     DUPLICATED_NICKNAME(409, "Duplicated Nickname"),
     ALREADY_EXIST_USER(409, "Already Exists User"),
     ALREADY_EXIST_PICKLE(409, "Already Exists Pickle"),
+    ALREADY_EXIST_STEP(409, "Alreay Exists Step"),
     ALREADY_STARTED_WAKA(409, "Already Started Wakatime"),
     OTHER_ROUTINE_ALREADY_USING_AT_DAY_OF_WEEK(409, "Other Routine Already Using At Day of week")
 }

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/exception/AlreadyExistStepException.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/exception/AlreadyExistStepException.kt
@@ -1,0 +1,6 @@
+package com.info.maeumgagym.step.exception
+
+import com.info.maeumgagym.common.exception.ErrorCode
+import com.info.maeumgagym.common.exception.MaeumGaGymException
+
+object AlreadyExistStepException : MaeumGaGymException(ErrorCode.ALREADY_EXIST_STEP)

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/exception/StepNotFoundException.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/exception/StepNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.info.maeumgagym.step.exception
+
+import com.info.maeumgagym.common.exception.ErrorCode
+import com.info.maeumgagym.common.exception.MaeumGaGymException
+
+object StepNotFoundException : MaeumGaGymException(ErrorCode.STEP_NOT_FOUND)

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/model/Step.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/model/Step.kt
@@ -1,0 +1,7 @@
+package com.info.maeumgagym.step.model
+
+data class Step(
+    val id: String,
+    val numberOfSteps: Int,
+    val ttl: Long
+)

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/port/in/CreateStepUseCase.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/port/in/CreateStepUseCase.kt
@@ -1,0 +1,5 @@
+package com.info.maeumgagym.step.port.`in`
+
+interface CreateStepUseCase {
+    fun createStep()
+}

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/port/in/UpdateStepUseCase.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/port/in/UpdateStepUseCase.kt
@@ -1,0 +1,5 @@
+package com.info.maeumgagym.step.port.`in`
+
+interface UpdateStepUseCase {
+    fun updateStep(numberOfSteps: Int)
+}

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/port/out/ReadStepPort.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/port/out/ReadStepPort.kt
@@ -1,0 +1,7 @@
+package com.info.maeumgagym.step.port.out
+
+import com.info.maeumgagym.step.model.Step
+
+interface ReadStepPort {
+    fun readStep(userId: String): Step?
+}

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/port/out/ReadStepPort.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/port/out/ReadStepPort.kt
@@ -3,5 +3,5 @@ package com.info.maeumgagym.step.port.out
 import com.info.maeumgagym.step.model.Step
 
 interface ReadStepPort {
-    fun readStep(userId: String): Step?
+    fun readByUserOauthId(oauthId: String): Step?
 }

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/port/out/SaveStepPort.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/port/out/SaveStepPort.kt
@@ -1,0 +1,7 @@
+package com.info.maeumgagym.step.port.out
+
+import com.info.maeumgagym.step.model.Step
+
+interface SaveStepPort {
+    fun saveStep(step: Step): Step
+}

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/port/out/SaveStepPort.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/port/out/SaveStepPort.kt
@@ -3,5 +3,5 @@ package com.info.maeumgagym.step.port.out
 import com.info.maeumgagym.step.model.Step
 
 interface SaveStepPort {
-    fun saveStep(step: Step): Step
+    fun save(step: Step): Step
 }

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/service/CreateStepService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/service/CreateStepService.kt
@@ -1,0 +1,42 @@
+package com.info.maeumgagym.step.service
+
+import com.info.common.UseCase
+import com.info.maeumgagym.auth.port.out.ReadCurrentUserPort
+import com.info.maeumgagym.step.exception.AlreadyExistStepException
+import com.info.maeumgagym.step.model.Step
+import com.info.maeumgagym.step.port.`in`.CreateStepUseCase
+import com.info.maeumgagym.step.port.out.ReadStepPort
+import com.info.maeumgagym.step.port.out.SaveStepPort
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+import java.time.LocalDateTime
+
+@UseCase
+@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
+internal class CreateStepService(
+    private val saveStepPort: SaveStepPort,
+    private val readStepPort: ReadStepPort,
+    private val readCurrentUserPort: ReadCurrentUserPort
+) : CreateStepUseCase {
+    override fun createStep() {
+        val user = readCurrentUserPort.readCurrentUser()
+        if (readStepPort.readStep(user.oauthId) != null) {
+            throw AlreadyExistStepException
+        }
+
+        saveStepPort.saveStep(
+            Step(
+                id = user.oauthId,
+                numberOfSteps = 0,
+                ttl = secondsUntilTomorrow()
+            )
+        )
+    }
+
+    private fun secondsUntilTomorrow(): Long {
+        val now = LocalDateTime.now()
+        val tomorrowStart = now.toLocalDate().plusDays(1).atStartOfDay()
+        return Duration.between(now, tomorrowStart).toSeconds()
+    }
+}

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/service/CreateStepService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/service/CreateStepService.kt
@@ -21,11 +21,11 @@ internal class CreateStepService(
 ) : CreateStepUseCase {
     override fun createStep() {
         val user = readCurrentUserPort.readCurrentUser()
-        if (readStepPort.readStep(user.oauthId) != null) {
+        if (readStepPort.readByUserOauthId(user.oauthId) != null) {
             throw AlreadyExistStepException
         }
 
-        saveStepPort.saveStep(
+        saveStepPort.save(
             Step(
                 id = user.oauthId,
                 numberOfSteps = 0,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/service/UpdateStepService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/service/UpdateStepService.kt
@@ -18,8 +18,8 @@ internal class UpdateStepService(
 ) : UpdateStepUseCase {
     override fun updateStep(numberOfSteps: Int) {
         val user = readCurrentUserPort.readCurrentUser()
-        val step = readStepPort.readStep(user.oauthId) ?: throw StepNotFoundException
+        val step = readStepPort.readByUserOauthId(user.oauthId) ?: throw StepNotFoundException
 
-        saveStepPort.saveStep(step.copy(numberOfSteps = numberOfSteps))
+        saveStepPort.save(step.copy(numberOfSteps = numberOfSteps))
     }
 }

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/service/UpdateStepService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/service/UpdateStepService.kt
@@ -1,0 +1,25 @@
+package com.info.maeumgagym.step.service
+
+import com.info.common.UseCase
+import com.info.maeumgagym.auth.port.out.ReadCurrentUserPort
+import com.info.maeumgagym.step.exception.StepNotFoundException
+import com.info.maeumgagym.step.port.`in`.UpdateStepUseCase
+import com.info.maeumgagym.step.port.out.ReadStepPort
+import com.info.maeumgagym.step.port.out.SaveStepPort
+import org.springframework.transaction.annotation.Isolation
+import org.springframework.transaction.annotation.Transactional
+
+@UseCase
+@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
+internal class UpdateStepService(
+    private val saveStepPort: SaveStepPort,
+    private val readStepPort: ReadStepPort,
+    private val readCurrentUserPort: ReadCurrentUserPort
+) : UpdateStepUseCase {
+    override fun updateStep(numberOfSteps: Int) {
+        val user = readCurrentUserPort.readCurrentUser()
+        val step = readStepPort.readStep(user.oauthId) ?: throw StepNotFoundException
+
+        saveStepPort.saveStep(step.copy(numberOfSteps = numberOfSteps))
+    }
+}

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/security/SecurityConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/security/SecurityConfig.kt
@@ -41,7 +41,7 @@ class SecurityConfig(
             }
         ).and()
             .formLogin().disable()
-//            .requiresChannel().anyRequest().requiresSecure().and() // XSS 공격 방지(HTTPS 요청 요구) local test시 주석 처리할 것
+            .requiresChannel().anyRequest().requiresSecure().and() // XSS 공격 방지(HTTPS 요청 요구) local test시 주석 처리할 것
             .sessionManagement()
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
             .authorizeRequests()

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/security/SecurityConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/security/SecurityConfig.kt
@@ -41,7 +41,7 @@ class SecurityConfig(
             }
         ).and()
             .formLogin().disable()
-            .requiresChannel().anyRequest().requiresSecure().and() // XSS 공격 방지(HTTPS 요청 요구) local test시 주석 처리할 것
+//            .requiresChannel().anyRequest().requiresSecure().and() // XSS 공격 방지(HTTPS 요청 요구) local test시 주석 처리할 것
             .sessionManagement()
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
             .authorizeRequests()

--- a/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/step/StepController.kt
+++ b/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/step/StepController.kt
@@ -1,0 +1,33 @@
+package com.info.maeumgagym.controller.step
+
+import com.info.common.WebAdapter
+import com.info.maeumgagym.step.port.`in`.CreateStepUseCase
+import com.info.maeumgagym.step.port.`in`.UpdateStepUseCase
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+
+@Tag(name = "Step API")
+@Validated
+@WebAdapter
+@RequestMapping("/step")
+class StepController(
+    private val createStepUseCase: CreateStepUseCase,
+    private val updateStepUseCase: UpdateStepUseCase
+) {
+
+    @Operation(summary = "걸음수 생성 API")
+    @PostMapping
+    fun createStep() = createStepUseCase.createStep()
+
+    @Operation(summary = "걸음수 수정 API")
+    @PutMapping
+    fun updateStep(
+        @RequestParam(name = "number_of_steps")
+        numberOfSteps: Int
+    ) = updateStepUseCase.updateStep(numberOfSteps)
+}


### PR DESCRIPTION
- 걸음수 생성, 수정 API 를 구현하였습니다.
- 걸음수가 하루가 지나면 초기화 되어야 한다는 요구사항에 Scheduler로 구현할 수 있었겠지만, Scheduler를 사용하는 리소스가 많은것을 예상하여 Redis TTL을 다음날까지의 남은 시간으로 설정하여 다음날이 되면 삭제될 수 있도록 구현하였습니다. 또한 Redis Expire Event를 이용하여 Redis Entity가 만료되었을때의 어떤 동작 ( 기록을 남긴다던지, 다음날 Step을 다시 생성한다던지 등 ) 으로 확장할 수 있습니다.
- Controller 부분에서 RequestParam으로 numberOfSteps을 받은 이유는 DTO로 받았을때의 역직렬화 직렬화 과정을 생략하여 조금 더 나은 성능을 기대할 수 있을것이라고 생각했습니다. <- 별로 좋지 않아보이면 말해주세요 