### PR TITLE
📝 :: 오늘의 루틴 컨트롤러 추가 및 없을 시 204 반환

### DIFF
--- a/maeumgagym-common/src/main/kotlin/com/info/common/UseCase.kt
+++ b/maeumgagym-common/src/main/kotlin/com/info/common/UseCase.kt
@@ -1,9 +1,11 @@
 package com.info.common
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 @MustBeDocumented
+@Transactional(readOnly = true)
 @Service
 annotation class UseCase()

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/dto/response/RoutineResponseWrapper.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/dto/response/RoutineResponseWrapper.kt
@@ -1,5 +1,0 @@
-package com.info.maeumgagym.routine.dto.response
-
-data class RoutineResponseWrapper(
-    val routineResponse: RoutineResponse?
-)

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/port/in/ReadTodayRoutineUseCase.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/port/in/ReadTodayRoutineUseCase.kt
@@ -1,8 +1,8 @@
 package com.info.maeumgagym.routine.port.`in`
 
-import com.info.maeumgagym.routine.dto.response.RoutineResponseWrapper
+import com.info.maeumgagym.routine.dto.response.RoutineResponse
 
 interface ReadTodayRoutineUseCase {
 
-    fun readTodayRoutine(): RoutineResponseWrapper
+    fun readTodayRoutine(): RoutineResponse?
 }

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/ReadTodayRoutineService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/ReadTodayRoutineService.kt
@@ -2,7 +2,7 @@ package com.info.maeumgagym.routine.service
 
 import com.info.common.UseCase
 import com.info.maeumgagym.auth.port.out.ReadCurrentUserPort
-import com.info.maeumgagym.routine.dto.response.RoutineResponseWrapper
+import com.info.maeumgagym.routine.dto.response.RoutineResponse
 import com.info.maeumgagym.routine.port.`in`.ReadTodayRoutineUseCase
 import com.info.maeumgagym.routine.port.out.ReadRoutinePort
 import java.time.LocalDate
@@ -13,10 +13,9 @@ class ReadTodayRoutineService(
     private val readCurrentUserPort: ReadCurrentUserPort
 ) : ReadTodayRoutineUseCase {
 
-    override fun readTodayRoutine(): RoutineResponseWrapper = RoutineResponseWrapper(
+    override fun readTodayRoutine(): RoutineResponse? =
         readRoutinePort.readByUserIdAndDayOfWeekAndIsArchivedFalse(
             readCurrentUserPort.readCurrentUser().id!!,
             LocalDate.now().dayOfWeek
         )?.run { toResponse() }
-    )
 }

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/routine/ReadRoutineServiceTests.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/routine/ReadRoutineServiceTests.kt
@@ -2,6 +2,7 @@ package com.info.maeumgagym.domain.routine
 
 import com.info.maeumgagym.domain.auth.AuthTestModule.saveInContext
 import com.info.maeumgagym.domain.routine.RoutineTestModule.appendDayOfWeek
+import com.info.maeumgagym.domain.routine.RoutineTestModule.deleteDayOfWeek
 import com.info.maeumgagym.domain.routine.RoutineTestModule.saveInRepository
 import com.info.maeumgagym.domain.routine.repository.RoutineRepository
 import com.info.maeumgagym.domain.user.UserTestModule
@@ -67,12 +68,21 @@ internal class ReadRoutineServiceTests @Autowired constructor(
 
     @Test
     fun readTodayRoutine() {
-        val todayDayOfWeek = LocalDate.now().dayOfWeek
-        RoutineTestModule.createTestRoutine(user.id!!).appendDayOfWeek(todayDayOfWeek)
+        RoutineTestModule.createTestRoutine(user.id!!).appendDayOfWeek(LocalDate.now().dayOfWeek)
             .saveInRepository(routineRepository)
 
         Assertions.assertNotNull(
-            readTodayRoutineUseCase.readTodayRoutine().routineResponse
+            readTodayRoutineUseCase.readTodayRoutine()
+        )
+    }
+
+    @Test
+    fun readTodayRoutineButNotExists() {
+        RoutineTestModule.createTestRoutine(user.id!!).deleteDayOfWeek(LocalDate.now().dayOfWeek)
+            .saveInRepository(routineRepository)
+
+        Assertions.assertNull(
+            readTodayRoutineUseCase.readTodayRoutine()
         )
     }
 }

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/routine/RoutineTestModule.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/routine/RoutineTestModule.kt
@@ -98,4 +98,15 @@ internal object RoutineTestModule {
             id = id,
             userId = userId
         )
+
+    fun RoutineJpaEntity.deleteDayOfWeek(dayOfWeek: DayOfWeek): RoutineJpaEntity =
+        RoutineJpaEntity(
+            routineName = routineName,
+            exerciseInfoList = exerciseInfoList,
+            dayOfWeeks = dayOfWeeks?.apply { remove(dayOfWeek) },
+            routineStatus = routineStatus,
+            createdAt = createdAt,
+            id = id,
+            userId = userId
+        )
 }

--- a/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/routine/RoutineController.kt
+++ b/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/routine/RoutineController.kt
@@ -4,15 +4,14 @@ import com.info.common.WebAdapter
 import com.info.maeumgagym.controller.routine.dto.CreateRoutineWebRequest
 import com.info.maeumgagym.controller.routine.dto.UpdateRoutineWebRequest
 import com.info.maeumgagym.routine.dto.response.RoutineListResponse
-import com.info.maeumgagym.routine.port.`in`.CreateRoutineUseCase
-import com.info.maeumgagym.routine.port.`in`.DeleteRoutineUseCase
-import com.info.maeumgagym.routine.port.`in`.ReadAllMyRoutineUseCase
-import com.info.maeumgagym.routine.port.`in`.UpdateRoutineUseCase
+import com.info.maeumgagym.routine.dto.response.RoutineResponse
+import com.info.maeumgagym.routine.port.`in`.*
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
+import javax.servlet.http.HttpServletResponse
 import javax.validation.Valid
 import javax.validation.constraints.Positive
 
@@ -21,8 +20,9 @@ import javax.validation.constraints.Positive
 @WebAdapter
 @Validated
 class RoutineController(
-    private val createRoutineUseCase: CreateRoutineUseCase,
+    private val readTodayRoutineUseCase: ReadTodayRoutineUseCase,
     private val readAllMyRoutineUseCase: ReadAllMyRoutineUseCase,
+    private val createRoutineUseCase: CreateRoutineUseCase,
     private val deleteRoutineUseCase: DeleteRoutineUseCase,
     private val updateRoutineUseCase: UpdateRoutineUseCase
 ) {
@@ -36,6 +36,13 @@ class RoutineController(
         createRoutineUseCase.createRoutine(req.toRequest())
     }
 
+    @Operation(summary = "오늘의 루틴 조회 API")
+    @GetMapping("/today")
+    fun readTodayRoutine(httpServletResponse: HttpServletResponse): RoutineResponse? =
+        readTodayRoutineUseCase.readTodayRoutine().apply {
+            if (this == null) httpServletResponse.status = 204
+        }
+
     @Operation(summary = "내 루틴 전체 조회 API")
     @GetMapping("/me/all")
     fun readAllMyRoutine(): RoutineListResponse = readAllMyRoutineUseCase.readAllMyRoutine()
@@ -47,7 +54,9 @@ class RoutineController(
         @Valid
         @Positive(message = "0보다 커야 합니다.")
         id: Long
-    ) { deleteRoutineUseCase.deleteRoutine(id) }
+    ) {
+        deleteRoutineUseCase.deleteRoutine(id)
+    }
 
     @Operation(summary = "루틴 수정 API")
     @PutMapping("/{id}")
@@ -58,5 +67,7 @@ class RoutineController(
         id: Long,
         @RequestBody @Valid
         req: UpdateRoutineWebRequest
-    ) { updateRoutineUseCase.updateRoutine(req.toRequest(), id) }
+    ) {
+        updateRoutineUseCase.updateRoutine(req.toRequest(), id)
+    }
 }


### PR DESCRIPTION
- 오늘의 루틴을 조회하는 컨트롤러를 추가했습니다; 이전 pr에서 누락되었습니다
- 오늘의 루틴이 없을 경우 204를 반환합니다.
-  Session(JPA의 Entity Manager의 구현체)이 Transaction 단위로 생명 주기를 가지기 때문에 Transaction이 없는(= JPARepository 내부에서만 Transaction이 형성되는) 로직에서는 Lazy Loading이 불가능하기 때문에 UseCase에 readOnly Transaction을 부착했습니다.