### PR TITLE
📝 :: UseCase와 ReadOnlyUseCase 분리

### DIFF
--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/routine/entity/RoutineJpaEntity.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/routine/entity/RoutineJpaEntity.kt
@@ -21,7 +21,7 @@ class RoutineJpaEntity(
     var routineName: String = routineName
         protected set
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     var exerciseInfoList: MutableList<ExerciseInfo> = exerciseInfoList
         protected set
 

--- a/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/routine/mapper/RoutineMapper.kt
+++ b/maeumgagym-application/src/main/kotlin/com/info/maeumgagym/domain/routine/mapper/RoutineMapper.kt
@@ -7,9 +7,12 @@ import com.info.maeumgagym.routine.model.ExerciseInfoModel
 import com.info.maeumgagym.routine.model.Routine
 import com.info.maeumgagym.routine.model.RoutineStatusModel
 import org.springframework.stereotype.Component
+import javax.persistence.EntityManager
 
 @Component
-class RoutineMapper {
+class RoutineMapper(
+    private val em: EntityManager
+) {
     fun toEntity(routine: Routine): RoutineJpaEntity = routine.run {
         RoutineJpaEntity(
             id = id,

--- a/maeumgagym-common/src/main/kotlin/com/info/common/ReadOnlyUseCase.kt
+++ b/maeumgagym-common/src/main/kotlin/com/info/common/ReadOnlyUseCase.kt
@@ -1,12 +1,11 @@
 package com.info.common
 
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Isolation
 import org.springframework.transaction.annotation.Transactional
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 @MustBeDocumented
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
+@Transactional(readOnly = true)
 @Service
-annotation class UseCase()
+annotation class ReadOnlyUseCase()

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/AppleOAuthService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/AppleOAuthService.kt
@@ -14,11 +14,8 @@ import com.info.maeumgagym.user.model.User
 import com.info.maeumgagym.user.port.out.ExistUserPort
 import com.info.maeumgagym.user.port.out.RecoveryUserPort
 import com.info.maeumgagym.user.port.out.SaveUserPort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class AppleOAuthService(
     private val saveUserPort: SaveUserPort,
     private val generateJwtPort: GenerateJwtPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/DuplicatedCheckService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/DuplicatedCheckService.kt
@@ -1,10 +1,10 @@
 package com.info.maeumgagym.auth.service
 
-import com.info.common.UseCase
+import com.info.common.ReadOnlyUseCase
 import com.info.maeumgagym.auth.port.`in`.DuplicatedNicknameCheckUseCase
 import com.info.maeumgagym.user.port.out.ExistUserPort
 
-@UseCase
+@ReadOnlyUseCase
 internal class DuplicatedCheckService(
     private val existUserPort: ExistUserPort
 ) : DuplicatedNicknameCheckUseCase {

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/GoogleOAuthService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/GoogleOAuthService.kt
@@ -2,22 +2,21 @@ package com.info.maeumgagym.auth.service
 
 import com.info.common.UseCase
 import com.info.maeumgagym.auth.exception.AlreadyExistUserException
-import com.info.maeumgagym.user.exception.DuplicatedNicknameException
-import com.info.maeumgagym.user.exception.UserNotFoundException
 import com.info.maeumgagym.auth.port.`in`.GoogleLoginUseCase
 import com.info.maeumgagym.auth.port.`in`.GoogleRecoveryUseCase
 import com.info.maeumgagym.auth.port.`in`.GoogleSignupUseCase
 import com.info.maeumgagym.auth.port.out.GenerateJwtPort
 import com.info.maeumgagym.auth.port.out.GetGoogleInfoPort
 import com.info.maeumgagym.auth.port.out.RevokeGoogleTokenPort
+import com.info.maeumgagym.user.exception.DuplicatedNicknameException
+import com.info.maeumgagym.user.exception.UserNotFoundException
 import com.info.maeumgagym.user.model.Role
 import com.info.maeumgagym.user.model.User
-import com.info.maeumgagym.user.port.out.*
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
+import com.info.maeumgagym.user.port.out.ExistUserPort
+import com.info.maeumgagym.user.port.out.RecoveryUserPort
+import com.info.maeumgagym.user.port.out.SaveUserPort
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class GoogleOAuthService(
     private val getGoogleInfoPort: GetGoogleInfoPort,
     private val saveUserPort: SaveUserPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/KakaoOAuthService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/KakaoOAuthService.kt
@@ -2,21 +2,20 @@ package com.info.maeumgagym.auth.service
 
 import com.info.common.UseCase
 import com.info.maeumgagym.auth.exception.AlreadyExistUserException
-import com.info.maeumgagym.auth.port.`in`.KakaoRecoveryUseCase
-import com.info.maeumgagym.user.exception.UserNotFoundException
 import com.info.maeumgagym.auth.port.`in`.KakaoLoginUseCase
+import com.info.maeumgagym.auth.port.`in`.KakaoRecoveryUseCase
 import com.info.maeumgagym.auth.port.`in`.KakaoSignupUseCase
 import com.info.maeumgagym.auth.port.out.GenerateJwtPort
 import com.info.maeumgagym.auth.port.out.GetKakaoInfoPort
 import com.info.maeumgagym.user.exception.DuplicatedNicknameException
+import com.info.maeumgagym.user.exception.UserNotFoundException
 import com.info.maeumgagym.user.model.Role
 import com.info.maeumgagym.user.model.User
-import com.info.maeumgagym.user.port.out.*
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
+import com.info.maeumgagym.user.port.out.ExistUserPort
+import com.info.maeumgagym.user.port.out.RecoveryUserPort
+import com.info.maeumgagym.user.port.out.SaveUserPort
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class KakaoOAuthService(
     private val getKakaoInfoPort: GetKakaoInfoPort,
     private val generateJwtPort: GenerateJwtPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/ReissueService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/ReissueService.kt
@@ -3,11 +3,8 @@ package com.info.maeumgagym.auth.service
 import com.info.common.UseCase
 import com.info.maeumgagym.auth.port.`in`.ReissueUseCase
 import com.info.maeumgagym.auth.port.out.ReissuePort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class ReissueService(
     private val reissuePort: ReissuePort
 ) : ReissueUseCase {

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/WithdrawalUserService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/service/WithdrawalUserService.kt
@@ -5,11 +5,8 @@ import com.info.maeumgagym.auth.port.`in`.WithdrawalUserUseCase
 import com.info.maeumgagym.auth.port.out.ReadCurrentUserPort
 import com.info.maeumgagym.auth.port.out.RevokeTokensPort
 import com.info.maeumgagym.user.port.out.DeleteUserPort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class WithdrawalUserService(
     private val deleteUserPort: DeleteUserPort,
     private val readCurrentUserPort: ReadCurrentUserPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/CreatePickleCommentService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/CreatePickleCommentService.kt
@@ -8,11 +8,8 @@ import com.info.maeumgagym.pickle.model.PickleComment
 import com.info.maeumgagym.pickle.port.`in`.CreatePickleCommentUseCase
 import com.info.maeumgagym.pickle.port.out.ExistsPicklePort
 import com.info.maeumgagym.pickle.port.out.SavePickleCommentPort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class CreatePickleCommentService(
     private val savePickleCommentPort: SavePickleCommentPort,
     private val readCurrentUserPort: ReadCurrentUserPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/CreatePickleReplyCommentService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/CreatePickleReplyCommentService.kt
@@ -11,11 +11,8 @@ import com.info.maeumgagym.pickle.port.`in`.CreatePickleReplyCommentUseCase
 import com.info.maeumgagym.pickle.port.out.ExistsPicklePort
 import com.info.maeumgagym.pickle.port.out.ReadPickleCommentPort
 import com.info.maeumgagym.pickle.port.out.SavePickleReplyPort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class CreatePickleReplyCommentService(
     private val savePickleReplyPort: SavePickleReplyPort,
     private val readCurrentUserPort: ReadCurrentUserPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/CreatePickleService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/CreatePickleService.kt
@@ -3,17 +3,17 @@ package com.info.maeumgagym.pickle.service
 import com.info.common.UseCase
 import com.info.maeumgagym.auth.port.out.ReadCurrentUserPort
 import com.info.maeumgagym.pickle.dto.request.CreatePickleRequest
-import com.info.maeumgagym.pickle.exception.*
+import com.info.maeumgagym.pickle.exception.AlreadyExistPickleException
+import com.info.maeumgagym.pickle.exception.NotUploadedToVideoServerException
+import com.info.maeumgagym.pickle.exception.TagTooLongException
+import com.info.maeumgagym.pickle.exception.VideoAndUploaderMismatchedException
 import com.info.maeumgagym.pickle.model.Pickle
 import com.info.maeumgagym.pickle.port.`in`.CreatePickleUseCase
 import com.info.maeumgagym.pickle.port.out.ExistsPicklePort
 import com.info.maeumgagym.pickle.port.out.ReadVideoIdAndUploaderIdPort
 import com.info.maeumgagym.pickle.port.out.SavePicklePort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class CreatePickleService(
     private val savePicklePort: SavePicklePort,
     private val existsPicklePort: ExistsPicklePort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/DeletePickleCommentService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/DeletePickleCommentService.kt
@@ -7,11 +7,8 @@ import com.info.maeumgagym.pickle.exception.PickleCommentNotFoundException
 import com.info.maeumgagym.pickle.port.`in`.DeletePickleCommentUseCase
 import com.info.maeumgagym.pickle.port.out.DeletePickleCommentPort
 import com.info.maeumgagym.pickle.port.out.ReadPickleCommentPort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class DeletePickleCommentService(
     private val deletePickleCommentPort: DeletePickleCommentPort,
     private val currentUserPort: ReadCurrentUserPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/DeletePickleReplyService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/DeletePickleReplyService.kt
@@ -7,11 +7,8 @@ import com.info.maeumgagym.pickle.exception.PickleReplyNotFoundException
 import com.info.maeumgagym.pickle.port.`in`.DeletePickleReplyUseCase
 import com.info.maeumgagym.pickle.port.out.DeletePickleReplyPort
 import com.info.maeumgagym.pickle.port.out.ReadPickleReplyPort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class DeletePickleReplyService(
     private val readCurrentUserPort: ReadCurrentUserPort,
     private val readPickleReplyPort: ReadPickleReplyPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/DeletePickleService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/DeletePickleService.kt
@@ -5,14 +5,11 @@ import com.info.maeumgagym.auth.exception.PermissionDeniedException
 import com.info.maeumgagym.auth.port.out.ReadCurrentUserPort
 import com.info.maeumgagym.pickle.exception.PickleNotFoundException
 import com.info.maeumgagym.pickle.port.`in`.DeletePickleUseCase
-import com.info.maeumgagym.pickle.port.out.DeletePicklePort
 import com.info.maeumgagym.pickle.port.out.DeleteOriginalVideoPort
+import com.info.maeumgagym.pickle.port.out.DeletePicklePort
 import com.info.maeumgagym.pickle.port.out.ReadPicklePort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class DeletePickleService(
     private val deletePicklePort: DeletePicklePort,
     private val deleteOriginalVideoPort: DeleteOriginalVideoPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/GetPreSignedURLService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/GetPreSignedURLService.kt
@@ -1,6 +1,6 @@
 package com.info.maeumgagym.pickle.service
 
-import com.info.common.UseCase
+import com.info.common.ReadOnlyUseCase
 import com.info.maeumgagym.auth.port.out.ReadCurrentUserPort
 import com.info.maeumgagym.pickle.dto.response.PreSignedUploadURLResponse
 import com.info.maeumgagym.pickle.exception.FileTypeMismatchedException
@@ -9,7 +9,7 @@ import com.info.maeumgagym.pickle.port.`in`.GetPreSignedUploadURLUseCase
 import com.info.maeumgagym.pickle.port.out.GetPreSignedVideoUploadURLPort
 import com.info.maeumgagym.pickle.port.out.SaveVideoIdAndUploaderIdPort
 
-@UseCase
+@ReadOnlyUseCase
 internal class GetPreSignedURLService(
     private val getPreSignedVideoUploadURLPort: GetPreSignedVideoUploadURLPort,
     private val saveVideoIdAndUploaderIdPort: SaveVideoIdAndUploaderIdPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/LikePickleService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/LikePickleService.kt
@@ -7,11 +7,8 @@ import com.info.maeumgagym.pickle.model.Pickle
 import com.info.maeumgagym.pickle.model.PickleLike
 import com.info.maeumgagym.pickle.port.`in`.LikePickleUseCase
 import com.info.maeumgagym.pickle.port.out.*
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class LikePickleService(
     private val savePickleLikePort: SavePickleLikePort,
     private val readPickleLikePort: ReadPickleLikePort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/LoadPickleService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/LoadPickleService.kt
@@ -61,7 +61,7 @@ internal class LoadPickleService(
     private fun getRandomPickles(pickles: List<Pickle>): List<Pickle> =
         // 만약 랜덤 피클을 추출할 베이스 리스트의 크기가 추출할 크기보다 작다면 -> 베이스 리스트 그대로 반환
         pickles.takeIf { pickles.toSet().size <= INDEX_SIZE }
-        // 아니라면 빈 Set을 생성해서 (중복 제거)
+            // 아니라면 빈 Set을 생성해서 (중복 제거)
             ?: mutableSetOf<Pickle>().apply {
                 // 총 개수가 INDEX_SIZE와 같아질 때까지 랜덤 피클 추가
                 while (size < INDEX_SIZE) add(pickles.random())

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/LoadPickleService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/LoadPickleService.kt
@@ -1,6 +1,6 @@
 package com.info.maeumgagym.pickle.service
 
-import com.info.common.UseCase
+import com.info.common.ReadOnlyUseCase
 import com.info.maeumgagym.pickle.dto.response.PickleListResponse
 import com.info.maeumgagym.pickle.dto.response.PickleResponse
 import com.info.maeumgagym.pickle.exception.PickleNotFoundException
@@ -15,7 +15,7 @@ import com.info.maeumgagym.pickle.port.out.ReadPicklePort
 import com.info.maeumgagym.pose.exception.PoseNotFoundException
 import com.info.maeumgagym.pose.port.out.ReadPosePort
 
-@UseCase
+@ReadOnlyUseCase
 internal class LoadPickleService(
     private val readPicklePort: ReadPicklePort,
     private val generateM3u8URLPort: GenerateM3u8URLPort,
@@ -61,7 +61,7 @@ internal class LoadPickleService(
     private fun getRandomPickles(pickles: List<Pickle>): List<Pickle> =
         // 만약 랜덤 피클을 추출할 베이스 리스트의 크기가 추출할 크기보다 작다면 -> 베이스 리스트 그대로 반환
         pickles.takeIf { pickles.toSet().size <= INDEX_SIZE }
-            // 아니라면 빈 Set을 생성해서 (중복 제거)
+        // 아니라면 빈 Set을 생성해서 (중복 제거)
             ?: mutableSetOf<Pickle>().apply {
                 // 총 개수가 INDEX_SIZE와 같아질 때까지 랜덤 피클 추가
                 while (size < INDEX_SIZE) add(pickles.random())

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/ReadAllPagedPickleCommentService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/ReadAllPagedPickleCommentService.kt
@@ -1,13 +1,13 @@
 package com.info.maeumgagym.pickle.service
 
-import com.info.common.UseCase
+import com.info.common.ReadOnlyUseCase
 import com.info.maeumgagym.pickle.dto.response.PickleCommentListResponse
 import com.info.maeumgagym.pickle.exception.PickleNotFoundException
 import com.info.maeumgagym.pickle.port.`in`.ReadAllPagedPickleCommentUseCase
 import com.info.maeumgagym.pickle.port.out.ExistsPicklePort
 import com.info.maeumgagym.pickle.port.out.ReadPickleCommentsPort
 
-@UseCase
+@ReadOnlyUseCase
 internal class ReadAllPagedPickleCommentService(
     private val existsPicklePort: ExistsPicklePort,
     private val readPickleCommentsPort: ReadPickleCommentsPort

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/ReadAllPickleReplyService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/ReadAllPickleReplyService.kt
@@ -1,13 +1,13 @@
 package com.info.maeumgagym.pickle.service
 
-import com.info.common.UseCase
+import com.info.common.ReadOnlyUseCase
 import com.info.maeumgagym.pickle.dto.response.PickleReplyListResponse
 import com.info.maeumgagym.pickle.exception.PickleCommentNotFoundException
 import com.info.maeumgagym.pickle.port.`in`.LoadAllPickleReplyUseCase
-import com.info.maeumgagym.pickle.port.out.ReadPickleReplyPort
 import com.info.maeumgagym.pickle.port.out.ReadPickleCommentPort
+import com.info.maeumgagym.pickle.port.out.ReadPickleReplyPort
 
-@UseCase
+@ReadOnlyUseCase
 internal class ReadAllPickleReplyService(
     private val readPickleReplyPort: ReadPickleReplyPort,
     private val readPickleCommentPort: ReadPickleCommentPort

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/UpdatePickleService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pickle/service/UpdatePickleService.kt
@@ -10,11 +10,8 @@ import com.info.maeumgagym.pickle.model.Pickle
 import com.info.maeumgagym.pickle.port.`in`.UpdatePickleUseCase
 import com.info.maeumgagym.pickle.port.out.ReadPicklePort
 import com.info.maeumgagym.pickle.port.out.SavePicklePort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class UpdatePickleService(
     private val savePicklePort: SavePicklePort,
     private val readCurrentUserPort: ReadCurrentUserPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pose/service/ReadPoseService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/pose/service/ReadPoseService.kt
@@ -1,12 +1,12 @@
 package com.info.maeumgagym.pose.service
 
-import com.info.common.UseCase
+import com.info.common.ReadOnlyUseCase
 import com.info.maeumgagym.pose.dto.response.PoseDetailResponse
 import com.info.maeumgagym.pose.exception.PoseNotFoundException
 import com.info.maeumgagym.pose.port.`in`.ReadByIdUseCase
 import com.info.maeumgagym.pose.port.out.ReadPosePort
 
-@UseCase
+@ReadOnlyUseCase
 internal class ReadPoseService(
     private val readPosePort: ReadPosePort
 ) : ReadByIdUseCase {

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/quote/service/ReadRandomQuoteService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/quote/service/ReadRandomQuoteService.kt
@@ -1,11 +1,11 @@
 package com.info.maeumgagym.quote.service
 
-import com.info.common.UseCase
+import com.info.common.ReadOnlyUseCase
 import com.info.maeumgagym.quote.dto.response.QuoteResponse
 import com.info.maeumgagym.quote.port.`in`.ReadRandomQuoteUseCase
 import com.info.maeumgagym.quote.vo.Quotes
 
-@UseCase
+@ReadOnlyUseCase
 internal class ReadRandomQuoteService : ReadRandomQuoteUseCase {
 
     override fun readRandomQuote(): QuoteResponse =

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/report/service/ReportService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/report/service/ReportService.kt
@@ -19,11 +19,8 @@ import com.info.maeumgagym.report.port.`in`.ReportUserUseCase
 import com.info.maeumgagym.report.port.out.SaveReportPort
 import com.info.maeumgagym.user.exception.UserNotFoundException
 import com.info.maeumgagym.user.port.out.ReadUserPort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class ReportService(
     private val readCurrentUserPort: ReadCurrentUserPort,
     private val saveReportPort: SaveReportPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/CreateRoutineService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/CreateRoutineService.kt
@@ -9,8 +9,6 @@ import com.info.maeumgagym.routine.model.RoutineStatusModel
 import com.info.maeumgagym.routine.port.`in`.CreateRoutineUseCase
 import com.info.maeumgagym.routine.port.out.ReadRoutinePort
 import com.info.maeumgagym.routine.port.out.SaveRoutinePort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 internal class CreateRoutineService(

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/CreateRoutineService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/CreateRoutineService.kt
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Isolation
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class CreateRoutineService(
     private val saveRoutinePort: SaveRoutinePort,
     private val readRoutinePort: ReadRoutinePort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/DeleteRoutineService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/DeleteRoutineService.kt
@@ -7,8 +7,6 @@ import com.info.maeumgagym.routine.exception.RoutineNotFoundException
 import com.info.maeumgagym.routine.port.`in`.DeleteRoutineUseCase
 import com.info.maeumgagym.routine.port.out.DeleteRoutinePort
 import com.info.maeumgagym.routine.port.out.ReadRoutinePort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 @UseCase
 internal class DeleteRoutineService(

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/DeleteRoutineService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/DeleteRoutineService.kt
@@ -11,7 +11,6 @@ import org.springframework.transaction.annotation.Isolation
 import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class DeleteRoutineService(
     private val deleteRoutinePort: DeleteRoutinePort,
     private val readRoutinePort: ReadRoutinePort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/ReadMyAllRoutineService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/ReadMyAllRoutineService.kt
@@ -1,13 +1,13 @@
 package com.info.maeumgagym.routine.service
 
-import com.info.common.UseCase
+import com.info.common.ReadOnlyUseCase
 import com.info.maeumgagym.auth.port.out.ReadCurrentUserPort
 import com.info.maeumgagym.routine.dto.response.RoutineListResponse
 import com.info.maeumgagym.routine.port.`in`.ReadAllMyRoutineUseCase
 import com.info.maeumgagym.routine.port.out.ReadRoutinePort
 import com.info.maeumgagym.user.dto.response.UserResponse
 
-@UseCase
+@ReadOnlyUseCase
 internal class ReadMyAllRoutineService(
     private val readRoutinePort: ReadRoutinePort,
     private val readCurrentUserPort: ReadCurrentUserPort

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/ReadTodayRoutineService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/ReadTodayRoutineService.kt
@@ -1,13 +1,13 @@
 package com.info.maeumgagym.routine.service
 
-import com.info.common.UseCase
+import com.info.common.ReadOnlyUseCase
 import com.info.maeumgagym.auth.port.out.ReadCurrentUserPort
 import com.info.maeumgagym.routine.dto.response.RoutineResponse
 import com.info.maeumgagym.routine.port.`in`.ReadTodayRoutineUseCase
 import com.info.maeumgagym.routine.port.out.ReadRoutinePort
 import java.time.LocalDate
 
-@UseCase
+@ReadOnlyUseCase
 class ReadTodayRoutineService(
     private val readRoutinePort: ReadRoutinePort,
     private val readCurrentUserPort: ReadCurrentUserPort

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/UpdateRoutineService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/routine/service/UpdateRoutineService.kt
@@ -11,11 +11,8 @@ import com.info.maeumgagym.routine.model.RoutineStatusModel
 import com.info.maeumgagym.routine.port.`in`.UpdateRoutineUseCase
 import com.info.maeumgagym.routine.port.out.ReadRoutinePort
 import com.info.maeumgagym.routine.port.out.SaveRoutinePort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class UpdateRoutineService(
     private val readRoutinePort: ReadRoutinePort,
     private val readCurrentUserPort: ReadCurrentUserPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/service/CreateStepService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/service/CreateStepService.kt
@@ -7,13 +7,10 @@ import com.info.maeumgagym.step.model.Step
 import com.info.maeumgagym.step.port.`in`.CreateStepUseCase
 import com.info.maeumgagym.step.port.out.ReadStepPort
 import com.info.maeumgagym.step.port.out.SaveStepPort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 import java.time.Duration
 import java.time.LocalDateTime
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class CreateStepService(
     private val saveStepPort: SaveStepPort,
     private val readStepPort: ReadStepPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/service/UpdateStepService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/step/service/UpdateStepService.kt
@@ -6,11 +6,8 @@ import com.info.maeumgagym.step.exception.StepNotFoundException
 import com.info.maeumgagym.step.port.`in`.UpdateStepUseCase
 import com.info.maeumgagym.step.port.out.ReadStepPort
 import com.info.maeumgagym.step.port.out.SaveStepPort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class UpdateStepService(
     private val saveStepPort: SaveStepPort,
     private val readStepPort: ReadStepPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/wakatime/service/EndWakatimeService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/wakatime/service/EndWakatimeService.kt
@@ -9,13 +9,10 @@ import com.info.maeumgagym.wakatime.model.WakaTime
 import com.info.maeumgagym.wakatime.port.`in`.EndWakatimeUseCase
 import com.info.maeumgagym.wakatime.port.out.ReadWakaTimePort
 import com.info.maeumgagym.wakatime.port.out.SaveWakaTimePort
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 import java.time.Duration
 import java.time.LocalDateTime
 
 @UseCase
-@Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class])
 internal class EndWakatimeService(
     private val readCurrentUserPort: ReadCurrentUserPort,
     private val saveUserPort: SaveUserPort,

--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/wakatime/service/StartWakatimeService.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/wakatime/service/StartWakatimeService.kt
@@ -6,12 +6,9 @@ import com.info.maeumgagym.user.model.User
 import com.info.maeumgagym.user.port.out.SaveUserPort
 import com.info.maeumgagym.wakatime.exception.AlreadyWakaStartedException
 import com.info.maeumgagym.wakatime.port.`in`.StartWakatimeUseCase
-import org.springframework.transaction.annotation.Isolation
-import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 @UseCase
-@Transactional(isolation = Isolation.SERIALIZABLE, rollbackFor = [Exception::class])
 internal class StartWakatimeService(
     private val readCurrentUserPort: ReadCurrentUserPort,
     private val saveUserPort: SaveUserPort


### PR DESCRIPTION
- @UseCase 어노테이션에 @Transactional(isolation = Isolation.REPEATABLE_READ, rollbackFor = [Exception::class]) 부착
- @UseCase의 @Transaction이 필요하지 않은(readOnly Transaction을 적용해야하는) UseCase들은 @ReadOnlyUseCase 부착