### PR TITLE
📝 :: SecurityConfig 분리 및 Filter 등 빈 등록

### DIFF
--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/MaeumGaGymApplication.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/MaeumGaGymApplication.kt
@@ -1,10 +1,8 @@
 package com.info.maeumgagym
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 
-@ConfigurationPropertiesScan(basePackages = ["com.info.maeumgagym.global.env"])
 @SpringBootApplication
 class MaeumGaGymApplication
 

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/filter/GlobalExceptionFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/filter/GlobalExceptionFilter.kt
@@ -1,10 +1,11 @@
 package com.info.maeumgagym.global.config.filter
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.info.maeumgagym.common.exception.MaeumGaGymException
 import com.info.maeumgagym.common.exception.ErrorCode
+import com.info.maeumgagym.common.exception.MaeumGaGymException
 import com.info.maeumgagym.global.error.ErrorResponse
 import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 import java.io.IOException
 import java.nio.charset.StandardCharsets
@@ -12,6 +13,7 @@ import javax.servlet.FilterChain
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
+@Component
 class GlobalExceptionFilter(
     private val objectMapper: ObjectMapper
 ) : OncePerRequestFilter() {

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/filter/MaeumGaGymExceptionFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/filter/MaeumGaGymExceptionFilter.kt
@@ -14,7 +14,7 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 @Component
-class GlobalExceptionFilter(
+class MaeumGaGymExceptionFilter(
     private val objectMapper: ObjectMapper
 ) : OncePerRequestFilter() {
 

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/scan/PropertiesScanConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/scan/PropertiesScanConfig.kt
@@ -1,15 +1,8 @@
 package com.info.maeumgagym.global.config.scan
 
-import com.info.maeumgagym.global.env.jwt.JwtProperties
-import com.info.maeumgagym.global.env.redis.RedisProperties
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.context.annotation.Configuration
 
-@ConfigurationPropertiesScan(
-    basePackageClasses = [
-        JwtProperties::class,
-        RedisProperties::class
-    ]
-)
+@ConfigurationPropertiesScan(basePackages = ["com.info.maeumgagym.global.env"])
 @Configuration
 class PropertiesScanConfig

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/security/CorsConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/security/CorsConfig.kt
@@ -1,0 +1,28 @@
+package com.info.maeumgagym.global.config.security
+
+import com.info.maeumgagym.global.env.security.SecurityProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+
+@Configuration
+class CorsConfig(
+    private val securityProperty: SecurityProperties
+) {
+
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration().apply {
+            allowedOrigins = listOf(securityProperty.frontDomain, securityProperty.backDomain)
+            allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD")
+            allowCredentials = true
+            addAllowedHeader("*")
+        }
+
+        return UrlBasedCorsConfigurationSource().apply {
+            registerCorsConfiguration("/**", configuration)
+        }
+    }
+}

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/security/RequestPermitConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/security/RequestPermitConfig.kt
@@ -1,0 +1,27 @@
+package com.info.maeumgagym.global.config.security
+
+import com.info.maeumgagym.user.model.Role
+import org.springframework.http.HttpMethod
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.DefaultSecurityFilterChain
+import org.springframework.stereotype.Component
+import org.springframework.web.cors.CorsUtils
+
+@Component
+class RequestPermitConfig : SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity>() {
+
+    override fun configure(builder: HttpSecurity) {
+        builder.authorizeRequests().run {
+            requestMatchers(CorsUtils::isCorsRequest).permitAll()
+            antMatchers(HttpMethod.POST, "/**/signup").permitAll()
+            antMatchers(HttpMethod.GET, "/**/login").permitAll()
+            antMatchers(HttpMethod.PUT, "/**/recovery").permitAll()
+            antMatchers(HttpMethod.GET, "/auth/re-issue").permitAll()
+            antMatchers(HttpMethod.GET, "/public/csrf").permitAll()
+            antMatchers(HttpMethod.GET, "/report").hasRole(Role.ADMIN.name)
+            antMatchers(HttpMethod.GET, "/actuator/health").permitAll()
+            anyRequest().authenticated()
+        }
+    }
+}

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/security/SecurityConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/security/SecurityConfig.kt
@@ -1,79 +1,55 @@
 package com.info.maeumgagym.global.config.security
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.info.maeumgagym.global.config.filter.FilterConfig
 import com.info.maeumgagym.global.env.security.CSRFProperties
-import com.info.maeumgagym.global.env.security.SecurityProperties
 import com.info.maeumgagym.global.error.CustomAccessDeniedHandler
 import com.info.maeumgagym.global.error.CustomAuthenticationEntryPoint
-import com.info.maeumgagym.global.jwt.JwtAdapter
-import com.info.maeumgagym.global.jwt.JwtResolver
-import com.info.maeumgagym.user.model.Role
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository
-import org.springframework.web.cors.CorsConfiguration
-import org.springframework.web.cors.CorsConfigurationSource
-import org.springframework.web.cors.CorsUtils
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
 class SecurityConfig(
-    private val objectMapper: ObjectMapper,
-    private val jwtResolver: JwtResolver,
-    private val jwtAdapter: JwtAdapter,
-    private val securityProperty: SecurityProperties,
-    private val csrfProperties: CSRFProperties
+    private val csrfProperties: CSRFProperties,
+    private val requestPermitConfig: RequestPermitConfig,
+    private val securityFilterChainConfig: SecurityFilterChainConfig,
+    private val accessDeniedHandler: CustomAccessDeniedHandler,
+    private val authenticationEntryPoint: CustomAuthenticationEntryPoint
 ) {
     @Bean
     protected fun filterChain(http: HttpSecurity): SecurityFilterChain =
-        http.csrf().csrfTokenRepository(
-            CookieCsrfTokenRepository().apply {
-                setSecure(true)
-                setCookieName(csrfProperties.cookie)
-                setHeaderName(csrfProperties.header)
-                setCookieHttpOnly(true)
-                setParameterName(csrfProperties.parameter)
-            }
-        ).and()
-            .formLogin().disable()
-            .requiresChannel().anyRequest().requiresSecure().and() // XSS 공격 방지(HTTPS 요청 요구) local test시 주석 처리할 것
+        http
+            .formLogin().disable() // Html Form 로그인 비활성화
+            .csrf().csrfTokenRepository(getCsrfTokenRepository()).and() // CSRF 설정
+            .cors().and() // CORS 활성화
+            //.requiresChannel().anyRequest().requiresSecure().and() // XSS Attack (HTTPS 요청 요구) local test시 주석 처리할 것
+
             .sessionManagement()
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
-            .authorizeRequests()
-            .requestMatchers(CorsUtils::isCorsRequest).permitAll()
-            .antMatchers(HttpMethod.POST, "/**/signup").permitAll()
-            .antMatchers(HttpMethod.GET, "/**/login").permitAll()
-            .antMatchers(HttpMethod.PUT, "/**/recovery").permitAll()
-            .antMatchers(HttpMethod.GET, "/auth/re-issue").permitAll()
-            .antMatchers(HttpMethod.GET, "/public/csrf").permitAll()
-            .antMatchers("/swagger-ui/**", "/docs/**").permitAll()
-            .antMatchers(HttpMethod.GET, "/report").hasRole(Role.ADMIN.name)
-            .antMatchers(HttpMethod.GET, "/actuator/health").permitAll()
-            .anyRequest().authenticated()
+
+            .exceptionHandling() // 인증 관련 예외에 관한 설정들
+            .accessDeniedHandler(accessDeniedHandler) // 인증 실패시 발생하는 예외에 대한 커스텀 예외로의 핸들링
+            .authenticationEntryPoint(authenticationEntryPoint)
             .and()
-            .cors().and()
-            .exceptionHandling().accessDeniedHandler(CustomAccessDeniedHandler(objectMapper, csrfProperties.header))
-            .authenticationEntryPoint(CustomAuthenticationEntryPoint(objectMapper)).and()
-            .headers().frameOptions().sameOrigin().and()
-            .apply(FilterConfig(objectMapper, jwtResolver, jwtAdapter))
+
+            .apply(requestPermitConfig).and() // 매핑에 따른 인증이 필요한지에 대한 설정
+            .authorizeRequests()
+            .antMatchers("/swagger-ui/**", "/docs/**").permitAll().and()
+
+            .headers().frameOptions().sameOrigin()
+            .and()
+
+            .apply(securityFilterChainConfig) // SecurityFilterChain에 대한 설정
             .and().build()
 
-    @Bean
-    fun corsConfigurationSource(): CorsConfigurationSource {
-        val configuration = CorsConfiguration().apply {
-            allowedOrigins = listOf(securityProperty.frontDomain, securityProperty.backDomain)
-            allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD")
-            allowCredentials = true
-            addAllowedHeader("*")
+    private fun getCsrfTokenRepository(): CookieCsrfTokenRepository =
+        CookieCsrfTokenRepository().apply {
+            setSecure(true)
+            setCookieName(csrfProperties.cookie)
+            setHeaderName(csrfProperties.header)
+            setCookieHttpOnly(true)
+            setParameterName(csrfProperties.parameter)
         }
-
-        return UrlBasedCorsConfigurationSource().apply {
-            registerCorsConfiguration("/**", configuration)
-        }
-    }
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/security/SecurityConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/security/SecurityConfig.kt
@@ -25,22 +25,22 @@ class SecurityConfig(
             .csrf().csrfTokenRepository(getCsrfTokenRepository()).and() // CSRF 설정
             .cors().and() // CORS 활성화
             //.requiresChannel().anyRequest().requiresSecure().and() // XSS Attack (HTTPS 요청 요구) local test시 주석 처리할 것
-
+//
             .sessionManagement()
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
-
+//
             .exceptionHandling() // 인증 관련 예외에 관한 설정들
             .accessDeniedHandler(accessDeniedHandler) // 인증 실패시 발생하는 예외에 대한 커스텀 예외로의 핸들링
             .authenticationEntryPoint(authenticationEntryPoint)
             .and()
-
+//
             .apply(requestPermitConfig).and() // 매핑에 따른 인증이 필요한지에 대한 설정
             .authorizeRequests()
             .antMatchers("/swagger-ui/**", "/docs/**").permitAll().and()
-
+//
             .headers().frameOptions().sameOrigin()
             .and()
-
+//
             .apply(securityFilterChainConfig) // SecurityFilterChain에 대한 설정
             .and().build()
 

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/security/SecurityFilterChainConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/config/security/SecurityFilterChainConfig.kt
@@ -1,9 +1,6 @@
-package com.info.maeumgagym.global.config.filter
+package com.info.maeumgagym.global.config.security
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.info.maeumgagym.global.jwt.JwtAdapter
 import com.info.maeumgagym.global.jwt.JwtFilter
-import com.info.maeumgagym.global.jwt.JwtResolver
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.web.DefaultSecurityFilterChain
@@ -11,16 +8,13 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.stereotype.Component
 
 @Component
-class FilterConfig(
-    private val objectMapper: ObjectMapper,
-    private val jwtResolver: JwtResolver,
-    private val jwtAdapter: JwtAdapter
+class SecurityFilterChainConfig(
+    private val jwtFilter: JwtFilter
 ) : SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity>() {
 
     override fun configure(builder: HttpSecurity) {
         builder.run {
-            addFilterBefore(JwtFilter(jwtResolver, jwtAdapter), UsernamePasswordAuthenticationFilter::class.java)
-            addFilterBefore(GlobalExceptionFilter(objectMapper), JwtFilter::class.java)
+            addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter::class.java)
         }
     }
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/error/CustomAccessDeniedHandler.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/error/CustomAccessDeniedHandler.kt
@@ -1,18 +1,21 @@
 package com.info.maeumgagym.global.error
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.info.maeumgagym.global.env.security.CSRFProperties
 import mu.KLogger
 import mu.KotlinLogging
 import org.springframework.core.log.LogMessage
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.stereotype.Component
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
+@Component
 class CustomAccessDeniedHandler(
     private val objectMapper: ObjectMapper,
-    private val headerName: String
+    private val csrfProperties: CSRFProperties
 ) : AccessDeniedHandler {
 
     private var errorPage: String? = null
@@ -33,7 +36,7 @@ class CustomAccessDeniedHandler(
             //response.sendError(HttpStatus.FORBIDDEN.value(), "csrf token missing")
 
             val responseBody = objectMapper.writeValueAsString(
-                request.getHeader(headerName)?.run {
+                request.getHeader(csrfProperties.header)?.run {
                     ErrorResponse(
                         403,
                         "Invalid CSRF Token"

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/error/CustomAuthenticationEntryPoint.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/error/CustomAuthenticationEntryPoint.kt
@@ -6,9 +6,11 @@ import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
+@Component
 class CustomAuthenticationEntryPoint(
     private val objectMapper: ObjectMapper
 ) : AuthenticationEntryPoint {

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/error/ErrorResponse.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/error/ErrorResponse.kt
@@ -1,6 +1,0 @@
-package com.info.maeumgagym.global.error
-
-data class ErrorResponse(
-    val status: Int,
-    val message: String?
-)

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/error/MaeumGaGymExceptionHandler.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/error/MaeumGaGymExceptionHandler.kt
@@ -53,3 +53,8 @@ class MaeumGaGymExceptionHandler {
             HttpStatus.BAD_REQUEST
         )
 }
+
+data class ErrorResponse(
+    val status: Int,
+    val message: String?
+)

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/error/MaeumGaGymExceptionHandler.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/error/MaeumGaGymExceptionHandler.kt
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import javax.validation.ConstraintViolationException
 
 @RestControllerAdvice
-class GlobalExceptionHandler {
+class MaeumGaGymExceptionHandler {
     @ExceptionHandler(MaeumGaGymException::class)
     fun handlingDefaultCustomException(e: MaeumGaGymException): ResponseEntity<ErrorResponse> =
         e.errorCode.run {

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/jwt/JwtFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/global/jwt/JwtFilter.kt
@@ -1,11 +1,13 @@
 package com.info.maeumgagym.global.jwt
 
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 import javax.servlet.FilterChain
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
+@Component
 class JwtFilter(
     private val jwtResolver: JwtResolver,
     private val jwtAdapter: JwtAdapter


### PR DESCRIPTION
- SecurityConfig에서 Cors 설정, RequestMapping에 따른 권한 설정을 분리
- FilterConfig -> SecurityFilterChainConfig로 수정 및 빈 등록
- JwtFilter 빈 등록
- GlobalExceptionFilter -> MaeumGaGymExceptionFilter로 수정 및 빈 등록
- GlobalExceptionHandler -> MaeumGaGymExceptionHandelr로 수정
- ErrorResponse를 MaeumGaGymExceptionHandler 내부로 이동
- CustomAccessDeniedHandler, CustomAuthenticationEntryPoint 빈 등록