### PR TITLE
PR :: Location Header 혹은 Body를 작성하지 않는 API에서 204 상태 코드 반환

### DIFF
--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/response/locationheader/LocationHeaderInterceptor.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/response/locationheader/LocationHeaderInterceptor.kt
@@ -71,6 +71,7 @@ class LocationHeaderInterceptor(
             response.setLocationHeader(request.requestURL.toString())
         } else {
             if (locationHeaderSubjectManager.getSubject() == null) {
+                response.status = HttpStatus.NO_CONTENT.value()
                 return
             }
             response.setLocationHeader("${request.requestURL}/${locationHeaderSubjectManager.getSubject()}")

--- a/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/auth/AppleAuthController.kt
+++ b/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/auth/AppleAuthController.kt
@@ -51,8 +51,8 @@ class AppleAuthController(
         }
 
     @Operation(summary = "애플 OAuth 회원가입 API")
-    @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/signup")
     fun signup(
         @RequestParam("access_token")
         token: String,
@@ -62,6 +62,7 @@ class AppleAuthController(
     ) { appleSignUpUseCase.signUp(token, req.nickname!!) }
 
     @Operation(summary = "애플 OAuth 회원복구 API")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PutMapping("/recovery")
     fun recovery(@RequestParam("access_token") token: String) {
         appleRecoveryUseCase.recovery(token)

--- a/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/auth/GoogleOAuthController.kt
+++ b/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/auth/GoogleOAuthController.kt
@@ -28,6 +28,7 @@ class GoogleOAuthController(
     private val googleRecoveryUseCase: GoogleRecoveryUseCase
 ) {
     @Operation(summary = "구글 OAuth 회원복구 API")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PutMapping("/recovery")
     fun recovery(@RequestParam("access_token") accessToken: String) {
         googleRecoveryUseCase.recovery(accessToken)

--- a/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/daily/DailyController.kt
+++ b/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/daily/DailyController.kt
@@ -37,8 +37,8 @@ class DailyController(
     ): PreSignedURLResponse = getDailyPreSignedURLUseCase.getUploadUrl(req.title!!)
 
     @Operation(description = "오운완 셍성 API")
-    @PostMapping("/daily")
     @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/daily")
     fun dailyUpload(
         @Valid
         @RequestBody
@@ -78,6 +78,7 @@ class DailyController(
     ): DailyListResponse = readDailyUseCase.readDailies(page, size)
 
     @Operation(description = "오운완 삭제 API")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/daily/{date}")
     fun dailyDelete(
         @Valid

--- a/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/daily/DailyController.kt
+++ b/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/daily/DailyController.kt
@@ -36,7 +36,7 @@ class DailyController(
         req: CreateDailyRequest
     ): PreSignedURLResponse = getDailyPreSignedURLUseCase.getUploadUrl(req.title!!)
 
-    @Operation(description = "오운완 셍성 API")
+    @Operation(description = "오운완 생성 API")
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/daily")
     fun dailyUpload(

--- a/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/pickle/PickleCommentController.kt
+++ b/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/pickle/PickleCommentController.kt
@@ -26,8 +26,8 @@ class PickleCommentController(
     private val locationHeaderSubjectManager: LocationHeaderSubjectManager
 ) {
     @Operation(summary = "피클 댓글 추가 API")
-    @PostMapping("/{videoId}")
     @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/{videoId}")
     fun createPickleComment(
         @RequestBody @Valid
         req: PickleCommentWebRequest,

--- a/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/pickle/PickleController.kt
+++ b/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/pickle/PickleController.kt
@@ -81,8 +81,8 @@ class PickleController(
     ): PreSignedUploadURLResponse = getPicklePreSignedURLUseCase.getUploadURL(req.fileType!!)
 
     @Operation(summary = "피클 생성 API")
-    @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
     fun createPickle(
         @RequestBody @Valid
         req: CreatePickleWebRequest

--- a/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/pickle/PickleReplyController.kt
+++ b/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/pickle/PickleReplyController.kt
@@ -26,8 +26,8 @@ class PickleReplyController(
     private val locationHeaderSubjectManager: LocationHeaderSubjectManager
 ) {
     @Operation(summary = "피클 대댓글 추가 API")
-    @PostMapping("/{videoId}/{parentId}")
     @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/{videoId}/{parentId}")
     fun createPickleReplyComment(
         @RequestBody @Valid
         req: PickleCommentWebRequest,
@@ -67,6 +67,7 @@ class PickleReplyController(
         readAllPickleReplyUseCase.loadAllPickleReply(parentId!!, page, size)
 
     @Operation(summary = "피클 대댓글 삭제 API")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{replyId}")
     fun deletePickleComment(
         @PathVariable(value = "replyId", required = false)

--- a/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/purpose/PurposeController.kt
+++ b/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/purpose/PurposeController.kt
@@ -10,6 +10,7 @@ import com.info.maeumgagym.purpose.port.`in`.*
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 import java.time.LocalDate
@@ -77,6 +78,7 @@ class PurposeController(
     }
 
     @Operation(summary = "목표 삭제 API")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{id}")
     fun purposeDelete(
         @Valid

--- a/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/routine/RoutineController.kt
+++ b/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/routine/RoutineController.kt
@@ -36,8 +36,8 @@ class RoutineController(
     private val readRoutineHistoryUseCase: ReadRoutineHistoryUseCase
 ) {
     @Operation(summary = "루틴 생성 API")
-    @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
     fun createRoutine(
         @RequestBody @Valid
         req: CreateRoutineWebRequest
@@ -57,6 +57,7 @@ class RoutineController(
     fun readAllMyRoutine(): RoutineListResponse = readAllMyRoutineUseCase.readAllMyRoutine()
 
     @Operation(summary = "루틴 삭제 API")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{id}")
     fun deleteRoutine(
         @PathVariable("id")
@@ -90,6 +91,7 @@ class RoutineController(
     ): RoutineResponse = readRoutineUseCase.readFromId(id)
 
     @Operation(summary = "오늘의 루틴 완료 API")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PutMapping("/today/complete")
     fun completeTodayRoutine() {
         completeTodayRoutineUseCase.complete()

--- a/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/step/StepController.kt
+++ b/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/step/StepController.kt
@@ -5,11 +5,9 @@ import com.info.maeumgagym.step.port.`in`.ReadTodayStepCountUseCase
 import com.info.maeumgagym.step.port.`in`.UpdateStepUseCase
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.*
 
 @Tag(name = "Step API")
 @Validated
@@ -20,6 +18,7 @@ class StepController(
     private val readTodayStepCountUseCase: ReadTodayStepCountUseCase
 ) {
     @Operation(summary = "걸음 수 카운트 업데이트 API")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PutMapping
     fun updateStep(
         @RequestParam(name = "number_of_steps")

--- a/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/user/UserController.kt
+++ b/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/user/UserController.kt
@@ -7,6 +7,7 @@ import com.info.maeumgagym.user.port.`in`.ReadUserUseCase
 import com.info.maeumgagym.user.port.`in`.UpdateUserInfoUseCase
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 import javax.validation.Valid
@@ -30,6 +31,7 @@ class UserController(
     ): UserProfileResponse = readUserUseCase.profileFromNickname(nickname!!)
 
     @Operation(summary = "유저 정보 수정 API")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PutMapping
     fun updateUserInfo(
         @RequestBody @Valid

--- a/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/wakatime/WakatimeController.kt
+++ b/maeumgagym-presentation/src/main/kotlin/com/info/maeumgagym/controller/wakatime/WakatimeController.kt
@@ -5,9 +5,11 @@ import com.info.maeumgagym.wakatime.port.`in`.EndWakatimeUseCase
 import com.info.maeumgagym.wakatime.port.`in`.StartWakatimeUseCase
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 
 @Tag(name = "Wakatime API")
 @Validated
@@ -19,12 +21,14 @@ class WakatimeController(
 ) {
 
     @Operation(summary = "와카타임 시작 API")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/start")
     fun startWakatime() {
         startWakatimeUseCase.startWakatime()
     }
 
     @Operation(summary = "와카 타임 종료 API")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/end")
     fun endWakatime() {
         endWakatimeUseCase.endWakatime()


### PR DESCRIPTION
#### Location Header 혹은 Body를 작성하지 않는 API에서 204 상태 코드 반환

<!--
Add one of the following kinds:
/kind 버그
/kind 리펙토링
/kind 문서
/kind 기능
-->

/kind 리팩토링

#### 이 PR이 무슨 일을 하나요? / 필요한 이유가 뭔가요?
아무런 정보도 반환하지 않는 API 응답에 대해서 204 상태 코드를 반환하도록 설정했습니다.
이에 더해, LocationHeaderManager에서 POST 혹은 PUT 요청에 대해 Body의 존재 여부를 확인해 204로 설정합니다. / 이로써 응답이 어떠한 정보를 반환하는지 확인하기에 더욱 편리합니다.

#### 리뷰어를 위한 참고사항:

```docs
API 중 204로 설정되지 않은 API가 있는지 확인해주세요.
204로 설정하면 안되는 API가 설정되었는지 확인해주세요.
```
