### PR TITLE
PR :: GoogleInfoResponse에서 locale 제거

### DIFF
--- a/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/dto/response/GoogleInfoResponse.kt
+++ b/maeumgagym-core/src/main/kotlin/com/info/maeumgagym/auth/dto/response/GoogleInfoResponse.kt
@@ -7,6 +7,5 @@ data class GoogleInfoResponse(
     val familyName: String?,
     val picture: String,
     val email: String,
-    val emailVerified: Boolean,
-    val locale: String
+    val emailVerified: Boolean
 )

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/external/feign/oauth/google/dto/GoogleInfoFeignResponse.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/external/feign/oauth/google/dto/GoogleInfoFeignResponse.kt
@@ -9,8 +9,7 @@ data class GoogleInfoFeignResponse(
     val familyName: String?,
     val picture: String,
     val email: String,
-    val emailVerified: Boolean,
-    val locale: String
+    val emailVerified: Boolean
 ) {
 
     fun toResponse() = GoogleInfoResponse(
@@ -20,7 +19,6 @@ data class GoogleInfoFeignResponse(
         familyName,
         picture,
         email,
-        emailVerified,
-        locale
+        emailVerified
     )
 }


### PR DESCRIPTION
#### 어떤 종류의 PR 인가요?

<!--
Add one of the following kinds:
/kind 버그
/kind 리펙토링
/kind 문서
/kind 기능
-->

/kind 버그

#### 이 PR이 무슨 일을 하나요? / 필요한 이유가 뭔가요?
Google OAuth 로그인 시, 사용자 Google 계정 정보를 Google OAuth 서버로부터 불러오는 과정에서 locale 필드가 null로 응답되는 경우가 있었습니다.
하지만 해당 필드는 사용되지 않는 필드이기에 제거하기로 결정했습니다.

#### 리뷰어를 위한 참고사항:

```docs

```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206876064848459