### PR TITLE
PR :: Authentication의 User를 LazyLoading으로 수정

### DIFF
--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/auth/ReadCurrentUserAdapter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/auth/ReadCurrentUserAdapter.kt
@@ -1,15 +1,33 @@
 package com.info.maeumgagym.auth
 
 import com.info.maeumgagym.auth.port.out.ReadCurrentUserPort
+import com.info.maeumgagym.common.exception.AuthenticationException
 import com.info.maeumgagym.security.principle.CustomUserDetails
 import com.info.maeumgagym.user.model.User
+import com.info.maeumgagym.user.port.out.ReadUserPort
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 
 @Component
-internal class ReadCurrentUserAdapter : ReadCurrentUserPort {
+internal class ReadCurrentUserAdapter(
+    private val readUserPort: ReadUserPort
+) : ReadCurrentUserPort {
 
-    override fun readCurrentUser(): User =
-        // jwt filter에서 집어 넣은 user를 context holder에서 꺼내오기
-        (SecurityContextHolder.getContext().authentication.principal as CustomUserDetails).user
+    override fun readCurrentUser(): User {
+
+        // jwt filter에서 생성한 authDetail를 context holder에서 불러옴
+        val authDetails = SecurityContextHolder.getContext().authentication.principal as CustomUserDetails
+
+        // Lazy Loading으로 Nullable인 User를 확인하고, null인 경우 User를 Load 및 입력
+        if (authDetails.getUser() == null) {
+            authDetails.fillUser(
+                readUserPort.readByOAuthId(authDetails.username)
+                // authDetails에 담긴 username = oauthId는 로직상 무조건 유저가 존재해야하므로 AuthenticationException throw
+                    ?: throw AuthenticationException(401, "User Not Found In ReadCurrentUserPort")
+            )
+        }
+
+        // 반환
+        return authDetails.getUser()!!
+    }
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/auth/ReadCurrentUserAdapter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/auth/ReadCurrentUserAdapter.kt
@@ -24,7 +24,7 @@ internal class ReadCurrentUserAdapter(
         if (authDetails.getUser() == null) {
             authDetails.fillUser(
                 readUserPort.readByOAuthId(authDetails.username)
-                // authDetails에 담긴 username = oauthId는 로직상 무조건 유저가 존재해야하므로 AuthenticationException throw
+                    // authDetails에 담긴 username = oauthId는 로직상 무조건 유저가 존재해야하므로 AuthenticationException throw
                     ?: throw AuthenticationException(401, "User Not Found In ReadCurrentUserPort")
             )
         }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/config/RequestPermitConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/config/RequestPermitConfig.kt
@@ -1,9 +1,9 @@
 package com.info.maeumgagym.security.config
 
-import com.info.maeumgagym.user.model.Role
 import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer
 import org.springframework.security.web.DefaultSecurityFilterChain
 import org.springframework.stereotype.Component
 import org.springframework.web.cors.CorsUtils
@@ -11,18 +11,40 @@ import org.springframework.web.cors.CorsUtils
 @Component
 class RequestPermitConfig : SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity>() {
 
+    internal companion object {
+        val permittedURI = mapOf<HttpMethod, String>(
+            Pair(HttpMethod.POST, "/**/signup"),
+            Pair(HttpMethod.GET, "/**/login"),
+            Pair(HttpMethod.PUT, "/**/recovery"),
+            Pair(HttpMethod.GET, "/auth/nickname/*"),
+            Pair(HttpMethod.GET, "/auth/re-issue"),
+            Pair(HttpMethod.GET, "/public/csrf"),
+            Pair(HttpMethod.GET, "/actuator/health")
+        )
+
+        val needAdminRoleURI = mapOf<HttpMethod, String>(
+            Pair(HttpMethod.GET, "/report")
+        )
+    }
+
     override fun configure(builder: HttpSecurity) {
         builder.authorizeRequests().run {
             requestMatchers(CorsUtils::isCorsRequest).permitAll()
-            antMatchers(HttpMethod.POST, "/**/signup").permitAll()
-            antMatchers(HttpMethod.GET, "/**/login").permitAll()
-            antMatchers(HttpMethod.PUT, "/**/recovery").permitAll()
-            antMatchers(HttpMethod.GET, "/auth/nickname/*").permitAll()
-            antMatchers(HttpMethod.GET, "/auth/re-issue").permitAll()
-            antMatchers(HttpMethod.GET, "/public/csrf").permitAll()
-            antMatchers(HttpMethod.GET, "/report").hasRole(Role.ADMIN.name)
-            antMatchers(HttpMethod.GET, "/actuator/health").permitAll()
+            permittedURIConfigure()
+            needAdminRoleURIConfigure()
             anyRequest().authenticated()
+        }
+    }
+
+    private fun ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry.permittedURIConfigure() {
+        permittedURI.forEach {
+            antMatchers(it.key, it.value).permitAll()
+        }
+    }
+
+    private fun ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry.needAdminRoleURIConfigure() {
+        permittedURI.forEach {
+            antMatchers(it.key, it.value).permitAll()
         }
     }
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/config/RequestPermitConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/config/RequestPermitConfig.kt
@@ -36,13 +36,15 @@ class RequestPermitConfig : SecurityConfigurerAdapter<DefaultSecurityFilterChain
         }
     }
 
-    private fun ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry.permittedURIConfigure() {
+    private fun ExpressionUrlAuthorizationConfigurer<HttpSecurity>
+    .ExpressionInterceptUrlRegistry.permittedURIConfigure() {
         permittedURI.forEach {
             antMatchers(it.key, it.value).permitAll()
         }
     }
 
-    private fun ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry.needAdminRoleURIConfigure() {
+    private fun ExpressionUrlAuthorizationConfigurer<HttpSecurity>
+    .ExpressionInterceptUrlRegistry.needAdminRoleURIConfigure() {
         permittedURI.forEach {
             antMatchers(it.key, it.value).permitAll()
         }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/config/SecurityConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/config/SecurityConfig.kt
@@ -20,15 +20,21 @@ class SecurityConfig(
     private val authenticationEntryPoint: CustomAuthenticationEntryPoint,
     private val logoutHandlerConfig: LogoutHandlerConfig
 ) {
+
+    internal companion object {
+        lateinit var securityFilterChain: SecurityFilterChain
+            protected set
+    }
+
     @Bean
-    protected fun filterChain(http: HttpSecurity): SecurityFilterChain =
-        http
+    protected fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        securityFilterChain = http
             .apply(logoutHandlerConfig::configure)
             .formLogin().disable() // Html Form 로그인 비활성화
 //            .csrf().csrfTokenRepository(getCsrfTokenRepository()).and() // CSRF 설정 (temporary disuse)
             .csrf().disable()
             .cors().and() // CORS 활성화
-            .requiresChannel().anyRequest().requiresSecure().and() // XSS Attack (HTTPS 요청 요구) local test시 주석 처리할 것
+            //.requiresChannel().anyRequest().requiresSecure().and() // XSS Attack (HTTPS 요청 요구) local test시 주석 처리할 것
 //
             .sessionManagement()
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
@@ -47,6 +53,9 @@ class SecurityConfig(
 //
             .apply(securityFilterChainConfig).and() // SecurityFilterChain에 대한 설정
             .build()
+
+        return securityFilterChain
+    }
 
     private fun getCsrfTokenRepository(): CookieCsrfTokenRepository =
         CookieCsrfTokenRepository().apply {

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/config/SecurityConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/config/SecurityConfig.kt
@@ -34,7 +34,7 @@ class SecurityConfig(
 //            .csrf().csrfTokenRepository(getCsrfTokenRepository()).and() // CSRF 설정 (temporary disuse)
             .csrf().disable()
             .cors().and() // CORS 활성화
-            //.requiresChannel().anyRequest().requiresSecure().and() // XSS Attack (HTTPS 요청 요구) local test시 주석 처리할 것
+            .requiresChannel().anyRequest().requiresSecure().and() // XSS Attack (HTTPS 요청 요구) local test시 주석 처리할 것
 //
             .sessionManagement()
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/jwt/AuthenticationProvider.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/jwt/AuthenticationProvider.kt
@@ -1,0 +1,22 @@
+package com.info.maeumgagym.security.jwt
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+
+/**
+ * [UsernamePasswordAuthenticationToken] 객체를 생성해주는 클래스
+ *
+ * @author Daybreak312
+ * @since 20-03-2024
+ */
+interface AuthenticationProvider {
+
+    /**
+     * 생성하는 [UsernamePasswordAuthenticationToken]의 [UsernamePasswordAuthenticationToken.principal] (AuthDetails)에 User를 조회에 User 정보를 담아 반환
+     */
+    fun getAuthentication(subject: String): UsernamePasswordAuthenticationToken
+
+    /**
+     * 생성하는 [UsernamePasswordAuthenticationToken]의 [UsernamePasswordAuthenticationToken.principal] (AuthDetails)에 User를 null로 삽입해 반환
+     */
+    fun getEmptyAuthentication(subject: String): UsernamePasswordAuthenticationToken
+}

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/jwt/JwtFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/jwt/JwtFilter.kt
@@ -1,28 +1,64 @@
 package com.info.maeumgagym.security.jwt
 
+import com.info.maeumgagym.common.exception.AuthenticationException
+import com.info.maeumgagym.security.config.RequestPermitConfig
+import com.info.maeumgagym.security.jwt.env.JwtProperties
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
+import org.springframework.util.AntPathMatcher
 import org.springframework.web.filter.OncePerRequestFilter
 import javax.servlet.FilterChain
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
+/**
+ * 서버의 커스텀 인증 Filter.
+ *
+ * 헤더를 통해 전해진 AccessToken의 유효성을 검증하고, 이에 따른 인가 작업을 진행
+ *
+ * @author Daybreak312, kanghyuk
+ */
 @Component
 class JwtFilter(
     private val jwtResolver: JwtResolver,
-    private val jwtAdapter: JwtAdapter
+    private val authenticationProvider: AuthenticationProvider,
+    private val jwtProperties: JwtProperties
 ) : OncePerRequestFilter() {
+
+    private var antPathMatcher: AntPathMatcher = AntPathMatcher()
 
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-        jwtResolver.resolveToken(request)?.let { // WHEN : 헤더에 토큰이 존재한다면
-            // security context holder에 user저장
-            SecurityContextHolder.getContext().authentication = jwtAdapter.getAuthentication(it)
+        // 헤더에 토큰이 존재하는지 확인, 아닐 경우 Exception 반환
+        val header = request.getHeader(jwtProperties.header)
+            ?: throw AuthenticationException.UNAUTHORIZED
+
+        // 토큰이 유효한지 확인, 유효하다면 ->
+        jwtResolver(header)?.let {
+            // security context holder에 Authentication 저장
+            SecurityContextHolder.getContext().authentication =
+                if (needRole(request)) { // Role 인증이 필요하다면 User Eager Loading
+                    authenticationProvider.getAuthentication(it)
+                } else { // 필요하지 않다면 User Lazy Loading
+                    authenticationProvider.getEmptyAuthentication(it)
+                }
         }
+
         // 다음 필터로 넘기기
         filterChain.doFilter(request, response)
+    }
+
+    private fun needRole(request: HttpServletRequest): Boolean {
+        RequestPermitConfig.needAdminRoleURI.forEach {
+            if (request.method == it.key.name &&
+                antPathMatcher.match(it.value, request.requestURI)
+            ) {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/jwt/JwtResolver.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/jwt/JwtResolver.kt
@@ -1,29 +1,18 @@
 package com.info.maeumgagym.security.jwt
 
-import com.info.maeumgagym.common.exception.AuthenticationException
-import com.info.maeumgagym.security.jwt.env.JwtProperties
-import com.info.maeumgagym.security.jwt.repository.AccessTokenRepository
-import org.springframework.stereotype.Component
-import javax.servlet.http.HttpServletRequest
+/**
+ * 주어진 토큰의 유효성을 확인하고, 그 여부에 따라 토큰과 연결된 OAuthId를 반환
+ *
+ * 유효성 : AccessToken인지, JWT 토큰인지, 해당 서버에서 발급했으며 저장이 되어 있는지(유효 기간이 지나지 않았는지)
+ *
+ * @author Daybreak312
+ * @since 20-03-2024
+ */
+interface JwtResolver {
 
-@Component
-class JwtResolver(
-    private val jwtProperties: JwtProperties,
-    private val accessTokenRepository: AccessTokenRepository
-) {
-    fun resolveToken(request: HttpServletRequest): String? =
-        // header에서 토큰을 찾을 수 없다면 null반환
-        request.getHeader(jwtProperties.header)?.let {
-            // WHEN : 정해진 prefix로 시작한다면
-            if (it.startsWith(jwtProperties.prefix)) {
-                // prefix slicing
-                val token = it.substring(jwtProperties.prefix.length).trimStart()
-
-                // 만료된 access_token인지 확인 및 반환, 예외처리
-                accessTokenRepository.findByAccessToken(token)?.subject
-                    ?: throw AuthenticationException.INVALID_TOKEN
-            } else {
-                throw AuthenticationException.INVALID_TOKEN // 정해진 prefix로 시작하지 않을 경우 Error반환
-            }
-        }
+    /**
+     * @param token 유효성을 확인할 토큰
+     * @return OAuthId, 토큰이 유효하지 않을 경우 null
+     */
+    operator fun invoke(token: String): String?
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/jwt/impl/AppleJwtParser.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/jwt/impl/AppleJwtParser.kt
@@ -1,4 +1,4 @@
-package com.info.maeumgagym.security.jwt
+package com.info.maeumgagym.security.jwt.impl
 
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Component
 import org.springframework.util.Base64Utils
 
 @Component
-class AppleJwtParser(private val objectMapper: ObjectMapper) : AppleJwtParsePort {
+class AppleJwtParser(
+    private val objectMapper: ObjectMapper
+) : AppleJwtParsePort {
 
     companion object {
         private const val IDENTITY_TOKEN_VALUE_DELIMITER = "\\."

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/jwt/impl/AuthenticationProviderImpl.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/jwt/impl/AuthenticationProviderImpl.kt
@@ -1,0 +1,42 @@
+package com.info.maeumgagym.security.jwt.impl
+
+import com.info.maeumgagym.common.exception.CriticalException
+import com.info.maeumgagym.security.jwt.AuthenticationProvider
+import com.info.maeumgagym.security.principle.CustomUserDetails
+import com.info.maeumgagym.user.port.out.ReadUserPort
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.stereotype.Component
+
+/**
+ * Docs는 상위 타입에 존재
+ *
+ * @author Daybreak312
+ * @since 20-03-2024
+ */
+@Component
+class AuthenticationProviderImpl(
+    private val userDetailsService: UserDetailsService,
+    private val readUserPort: ReadUserPort
+) : AuthenticationProvider {
+
+    override fun getAuthentication(subject: String): UsernamePasswordAuthenticationToken {
+        // UserDetails 생성
+        val authDetails = userDetailsService.loadUserByUsername(subject) as CustomUserDetails
+
+        val user = readUserPort.readByOAuthId(subject)
+            ?: throw CriticalException(500, "User Not Found In AuthenticationProvider")
+
+        authDetails.fillUser(user)
+
+        // Authentication발급
+        return UsernamePasswordAuthenticationToken(authDetails, null, authDetails.authorities)
+    }
+
+    override fun getEmptyAuthentication(subject: String): UsernamePasswordAuthenticationToken {
+        // UserDetails 생성
+        val authDetails = userDetailsService.loadUserByUsername(subject) as CustomUserDetails
+
+        return UsernamePasswordAuthenticationToken(authDetails, null, null)
+    }
+}

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/jwt/impl/JwtAdapter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/jwt/impl/JwtAdapter.kt
@@ -1,19 +1,19 @@
-package com.info.maeumgagym.security.jwt
+package com.info.maeumgagym.security.jwt.impl
 
-import com.info.maeumgagym.auth.port.out.*
+import com.info.maeumgagym.auth.port.out.GenerateJwtPort
+import com.info.maeumgagym.auth.port.out.GetJwtBodyPort
+import com.info.maeumgagym.auth.port.out.ReissuePort
+import com.info.maeumgagym.auth.port.out.RevokeTokensPort
 import com.info.maeumgagym.common.exception.AuthenticationException
-import com.info.maeumgagym.security.jwt.env.JwtProperties
 import com.info.maeumgagym.security.jwt.entity.AccessTokenRedisEntity
 import com.info.maeumgagym.security.jwt.entity.RefreshTokenRedisEntity
+import com.info.maeumgagym.security.jwt.env.JwtProperties
 import com.info.maeumgagym.security.jwt.repository.AccessTokenRepository
 import com.info.maeumgagym.security.jwt.repository.RefreshTokenRepository
-import com.info.maeumgagym.security.principle.CustomUserDetailService
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
-import org.springframework.security.core.Authentication
 import org.springframework.stereotype.Component
 import java.security.PublicKey
 import java.util.*
@@ -21,7 +21,6 @@ import java.util.*
 @Component
 class JwtAdapter(
     private val jwtProperties: JwtProperties,
-    private val customUserDetailService: CustomUserDetailService,
     private val refreshTokenRepository: RefreshTokenRepository,
     private val accessTokenRepository: AccessTokenRepository
 ) : GenerateJwtPort, ReissuePort, GetJwtBodyPort, RevokeTokensPort {
@@ -99,15 +98,6 @@ class JwtAdapter(
 
         // 토큰 재발급 및 반환
         return generateTokens(rfToken.subject)
-    }
-
-    // 토큰의 subject값으로 Authentication얻는 함수
-    fun getAuthentication(subject: String): Authentication {
-        // CustomUserDetails로 갑싼 user 불러오기
-        val authDetails = customUserDetailService.loadUserByUsername(subject)
-
-        // Authentication발급
-        return UsernamePasswordAuthenticationToken(authDetails, null, authDetails.authorities)
     }
 
     // Apple id_token parsing 함수

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/jwt/impl/JwtResolverImpl.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/jwt/impl/JwtResolverImpl.kt
@@ -1,0 +1,33 @@
+package com.info.maeumgagym.security.jwt.impl
+
+import com.info.maeumgagym.common.exception.AuthenticationException
+import com.info.maeumgagym.security.jwt.JwtResolver
+import com.info.maeumgagym.security.jwt.env.JwtProperties
+import com.info.maeumgagym.security.jwt.repository.AccessTokenRepository
+import org.springframework.stereotype.Component
+
+/**
+ * Docs는 상위 타입에 존재
+ *
+ * @author Daybreak312
+ * @since 20-03-2024
+ */
+@Component
+class JwtResolverImpl(
+    private val jwtProperties: JwtProperties,
+    private val accessTokenRepository: AccessTokenRepository
+) : JwtResolver {
+    override fun invoke(token: String): String? =
+        // 토큰이 JWT 토큰일 경우 = 특정 Prefix로 시작하는 토큰일 경우
+        if (token.startsWith(jwtProperties.prefix)) {
+
+            // Prefix 제거
+            val slicedToken = token.substring(jwtProperties.prefix.length).trimStart()
+
+            // 만료된 access_token인지 확인 및 반환, 예외처리
+            accessTokenRepository.findByAccessToken(slicedToken)?.subject
+                ?: throw AuthenticationException.INVALID_TOKEN
+        } else {
+            throw AuthenticationException.INVALID_TOKEN // 정해진 Prefix로 시작하지 않을 경우 Exception 발생
+        }
+}

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/jwt/impl/JwtResolverImpl.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/jwt/impl/JwtResolverImpl.kt
@@ -20,7 +20,6 @@ class JwtResolverImpl(
     override fun invoke(token: String): String? =
         // 토큰이 JWT 토큰일 경우 = 특정 Prefix로 시작하는 토큰일 경우
         if (token.startsWith(jwtProperties.prefix)) {
-
             // Prefix 제거
             val slicedToken = token.substring(jwtProperties.prefix.length).trimStart()
 

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/principle/CustomUserDetailService.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/principle/CustomUserDetailService.kt
@@ -8,7 +8,6 @@ class CustomUserDetailService : UserDetailsService {
 
     // 유저를 DB에서 불러와 UserDetails를 반환하는 함수
     override fun loadUserByUsername(username: String): CustomUserDetails {
-
         // CustomUserDetails에 User를 null로 삽입해 반환
         return CustomUserDetails(null, username)
     }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/principle/CustomUserDetailService.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/principle/CustomUserDetailService.kt
@@ -1,21 +1,15 @@
 package com.info.maeumgagym.security.principle
 
-import com.info.maeumgagym.common.exception.BusinessLogicException
-import com.info.maeumgagym.user.port.out.ReadUserPort
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.stereotype.Component
 
 @Component
-class CustomUserDetailService(
-    private val readUserPort: ReadUserPort
-) : UserDetailsService {
+class CustomUserDetailService : UserDetailsService {
 
     // 유저를 DB에서 불러와 UserDetails를 반환하는 함수
-    override fun loadUserByUsername(username: String?): CustomUserDetails {
-        // user를 전달 받은 UK값으로 불러오기
-        val user = readUserPort.readByOAuthId(username!!) ?: throw BusinessLogicException.USER_NOT_FOUND
+    override fun loadUserByUsername(username: String): CustomUserDetails {
 
-        // CustomUserDetails로 형변환 후 반환
-        return CustomUserDetails(user)
+        // CustomUserDetails에 User를 null로 삽입해 반환
+        return CustomUserDetails(null, username)
     }
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/principle/CustomUserDetails.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/principle/CustomUserDetails.kt
@@ -6,17 +6,26 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
 
 class CustomUserDetails(
-    val user: User
+    private var user: User?,
+    private val oauthId: String
 ) : UserDetails {
 
+    fun getUser(): User? = user
+
+    fun fillUser(user: User) {
+        if (this.user == null) {
+            this.user = user
+        }
+    }
+
     override fun getAuthorities(): MutableCollection<out GrantedAuthority> =
-        user.roles.map {
+        user?.roles?.map {
             SimpleGrantedAuthority(it.name)
-        }.toMutableList()
+        }?.toMutableList() ?: mutableListOf()
 
     override fun getPassword(): String? = null
 
-    override fun getUsername(): String = user.oauthId
+    override fun getUsername(): String = oauthId
 
     override fun isAccountNonExpired(): Boolean = true
 

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/auth/AuthTestModule.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/auth/AuthTestModule.kt
@@ -14,7 +14,7 @@ internal object AuthTestModule {
     fun UserJpaEntity.saveInContext(userMapper: UserMapper): UserJpaEntity =
         apply {
             SecurityContextHolder.getContext().authentication =
-                CustomUserDetails(userMapper.toDomain(this)).run {
+                CustomUserDetails(userMapper.toDomain(this), this.oauthId).run {
                     UsernamePasswordAuthenticationToken(this, null, this.authorities)
                 }
         }

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/auth/JwtTests.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/auth/JwtTests.kt
@@ -6,9 +6,9 @@ import com.info.maeumgagym.domain.user.UserTestModule.saveInRepository
 import com.info.maeumgagym.domain.user.entity.UserJpaEntity
 import com.info.maeumgagym.domain.user.repository.UserRepository
 import com.info.maeumgagym.error.TestException
-import com.info.maeumgagym.security.jwt.JwtAdapter
+import com.info.maeumgagym.security.jwt.impl.JwtAdapter
 import com.info.maeumgagym.security.jwt.JwtFilter
-import com.info.maeumgagym.security.jwt.JwtResolver
+import com.info.maeumgagym.security.jwt.impl.JwtResolverImpl
 import com.info.maeumgagym.security.jwt.repository.AccessTokenRepository
 import com.info.maeumgagym.security.jwt.repository.RefreshTokenRepository
 import org.junit.jupiter.api.Assertions
@@ -25,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional
 @SpringBootTest
 internal class JwtTests @Autowired constructor(
     private val jwtAdapter: JwtAdapter,
-    private val jwtResolver: JwtResolver,
+    private val jwtResolver: JwtResolverImpl,
     private val accessTokenRepository: AccessTokenRepository,
     private val userRepository: UserRepository,
     private val refreshTokenRepository: RefreshTokenRepository
@@ -112,7 +112,7 @@ internal class JwtTests @Autowired constructor(
     }
 
     /**
-     * @see JwtResolver.resolveToken
+     * @see JwtResolverImpl.resolveToken
      * @when 성공 상황
      * @fail 환경 변수로 주입된 jwtPrefix가 잘못되었는지 확인
      * @fail header의 이름이 잘못되었는지 확인
@@ -130,7 +130,7 @@ internal class JwtTests @Autowired constructor(
     }
 
     /**
-     * @see JwtResolver.resolveToken
+     * @see JwtResolverImpl.resolveToken
      * @when 실패 상황
      * @success "Bearer " 접두사가 존재하지 않아 InvalidTokenException 발생
      * @fail jwtPrefix 환경 변수가 주입되었는지 확인
@@ -155,7 +155,7 @@ internal class JwtTests @Autowired constructor(
     }
 
     /**
-     * @see JwtResolver.resolveToken
+     * @see JwtResolverImpl.resolveToken
      * @when 실패 상황
      * @success 인증 헤더에 AccessToken 대신 RefreshToken이 담겨있으므로 InvalidException 발생
      * @fail AccessTokenRepository에 정상적으로 토큰이 저장되는지 확인
@@ -171,7 +171,7 @@ internal class JwtTests @Autowired constructor(
     }
 
     /**
-     * @see JwtResolver.resolveToken
+     * @see JwtResolverImpl.resolveToken
      * @when 실패 상황
      * @success 인증 관련 헤더가 비어있으므로 유저 정보 대신 null 반환
      * @fail

--- a/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/auth/JwtTests.kt
+++ b/maeumgagym-infrastructure/src/test/kotlin/com/info/maeumgagym/domain/auth/JwtTests.kt
@@ -6,8 +6,8 @@ import com.info.maeumgagym.domain.user.UserTestModule.saveInRepository
 import com.info.maeumgagym.domain.user.entity.UserJpaEntity
 import com.info.maeumgagym.domain.user.repository.UserRepository
 import com.info.maeumgagym.error.TestException
-import com.info.maeumgagym.security.jwt.impl.JwtAdapter
 import com.info.maeumgagym.security.jwt.JwtFilter
+import com.info.maeumgagym.security.jwt.impl.JwtAdapter
 import com.info.maeumgagym.security.jwt.impl.JwtResolverImpl
 import com.info.maeumgagym.security.jwt.repository.AccessTokenRepository
 import com.info.maeumgagym.security.jwt.repository.RefreshTokenRepository
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 @SpringBootTest
 internal class JwtTests @Autowired constructor(
+    private val jwtFilter: JwtFilter,
     private val jwtAdapter: JwtAdapter,
     private val jwtResolver: JwtResolverImpl,
     private val accessTokenRepository: AccessTokenRepository,
@@ -31,7 +32,6 @@ internal class JwtTests @Autowired constructor(
     private val refreshTokenRepository: RefreshTokenRepository
 ) {
 
-    private val jwtFilter = JwtFilter(jwtResolver, jwtAdapter)
     private lateinit var user: UserJpaEntity
 
     @BeforeEach
@@ -112,7 +112,7 @@ internal class JwtTests @Autowired constructor(
     }
 
     /**
-     * @see JwtResolverImpl.resolveToken
+     * @see JwtResolverImpl.invoke
      * @when 성공 상황
      * @fail 환경 변수로 주입된 jwtPrefix가 잘못되었는지 확인
      * @fail header의 이름이 잘못되었는지 확인
@@ -120,24 +120,21 @@ internal class JwtTests @Autowired constructor(
      * */
     @Test
     fun resolve() {
-        val request = MockHttpServletRequest()
         val accessToken = jwtAdapter.generateTokens(user.oauthId).first
-        request.addHeader(AuthTestModule.TOKEN_HEADER, AuthTestModule.TOKEN_PREFIX + accessToken)
         Assertions.assertEquals(
-            jwtResolver.resolveToken(request),
+            jwtResolver(AuthTestModule.TOKEN_PREFIX + accessToken),
             user.oauthId
         )
     }
 
     /**
-     * @see JwtResolverImpl.resolveToken
+     * @see JwtResolverImpl.invoke
      * @when 실패 상황
      * @success "Bearer " 접두사가 존재하지 않아 InvalidTokenException 발생
      * @fail jwtPrefix 환경 변수가 주입되었는지 확인
      */
     @Test
     fun resolveWithJwtAnyToken() {
-        val request = MockHttpServletRequest()
         lateinit var accessToken: String
         lateinit var refreshToken: String
         jwtAdapter.generateTokens(user.oauthId).run {
@@ -145,33 +142,29 @@ internal class JwtTests @Autowired constructor(
             refreshToken = this.second
         }
         TestException.assertThrowsMaeumGaGymExceptionInstance(AuthenticationException.INVALID_TOKEN) {
-            request.addHeader(AuthTestModule.TOKEN_HEADER, accessToken)
-            jwtResolver.resolveToken(request)
+            jwtResolver(accessToken)
         }
         TestException.assertThrowsMaeumGaGymExceptionInstance(AuthenticationException.INVALID_TOKEN) {
-            request.addHeader(AuthTestModule.TOKEN_HEADER, refreshToken)
-            jwtResolver.resolveToken(request)
+            jwtResolver(refreshToken)
         }
     }
 
     /**
-     * @see JwtResolverImpl.resolveToken
+     * @see JwtResolverImpl.invoke
      * @when 실패 상황
      * @success 인증 헤더에 AccessToken 대신 RefreshToken이 담겨있으므로 InvalidException 발생
      * @fail AccessTokenRepository에 정상적으로 토큰이 저장되는지 확인
      */
     @Test
     fun resolveWithBearerRefreshToken() {
-        val request = MockHttpServletRequest()
         val refreshToken = jwtAdapter.generateTokens(user.oauthId).second
-        request.addHeader(AuthTestModule.TOKEN_HEADER, AuthTestModule.TOKEN_HEADER + refreshToken)
         TestException.assertThrowsMaeumGaGymExceptionInstance(AuthenticationException.INVALID_TOKEN) {
-            jwtResolver.resolveToken(request)
+            jwtResolver(AuthTestModule.TOKEN_HEADER + refreshToken)
         }
     }
 
     /**
-     * @see JwtResolverImpl.resolveToken
+     * @see JwtResolverImpl.invoke
      * @when 실패 상황
      * @success 인증 관련 헤더가 비어있으므로 유저 정보 대신 null 반환
      * @fail
@@ -179,7 +172,7 @@ internal class JwtTests @Autowired constructor(
     @Test
     fun resolveWithNothing() {
         Assertions.assertNull(
-            jwtResolver.resolveToken(MockHttpServletRequest())
+            jwtResolver("")
         )
     }
 


### PR DESCRIPTION
#### 어떤 종류의 PR 인가요?
/kind 리펙토링
<!--
Add one of the following kinds:
/kind 버그
/kind 리펙토링
/kind 문서
/kind 기능
-->

#### 이 PR이 무슨 일을 하나요? / 필요한 이유가 뭔가요?
JwtFilter의 인증 과정에서 User를 SELECT할 이유가 없음에도 User를 불러와 필요하지 않은 Query가 날아감
ex) 피클 추천 조회 API 등 AccessToken의 유효 여부만 확인하면 되는 경우

이를 해결하기 위해, JwtFilter 로직에서 Authentication을 생성할 때 User가 null로 삽입된 CustomAuthDetails를 사용하고,
ReadCurrentUserPort 호출 시 User를 Load하도록 수정했습니다.

#### 리뷰어를 위한 참고사항:

```docs

```
