### PR TITLE
PR :: Controller에서 발생한 DateTimeException에 대한 예외 처리

### DIFF
--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ErrorLogResponseFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ErrorLogResponseFilter.kt
@@ -73,7 +73,7 @@ class ErrorLogResponseFilter(
                     exceptionClassName = javaClass.name,
                     errorOccurredClassName = stackTrace[2].className + " or " + stackTrace[1].className,
                     status = status,
-                    message = fields.map {
+                    message = "$message, " + fields.map {
                         "${it.key}: ${it.value}"
                     }.toString()
                 )

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ExceptionConvertFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ExceptionConvertFilter.kt
@@ -81,7 +81,7 @@ class ExceptionConvertFilter(
         } catch (e: DateTimeException) {
             throw PresentationValidationException(
                 status = 400,
-                message = e.message ?: "DateTime Format Wrong",
+                message = "DateTime Format Wrong",
                 fields = mapOf()
             )
         }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/handler/CustomExceptionHandler.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/handler/CustomExceptionHandler.kt
@@ -1,0 +1,17 @@
+package com.info.maeumgagym.error.handler
+
+import com.info.maeumgagym.error.repository.ExceptionRepository
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+import java.time.DateTimeException
+
+@ControllerAdvice
+class CustomExceptionHandler(
+    private val exceptionRepository: ExceptionRepository
+) {
+
+    @ExceptionHandler(DateTimeException::class)
+    fun dateTimeExceptionHandler(e: DateTimeException) {
+        exceptionRepository.save(e)
+    }
+}

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepository.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepository.kt
@@ -1,0 +1,9 @@
+package com.info.maeumgagym.error.repository
+
+interface ExceptionRepository {
+
+    fun save(e: Exception)
+
+    @Throws(Exception::class)
+    fun throwIt()
+}

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepository.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepository.kt
@@ -1,5 +1,11 @@
 package com.info.maeumgagym.error.repository
 
+/**
+ * 경우에 따라, 생성된 Exception을 저장해두었다가 다른 위치에서 발생시킬 수 있도록 Thread에 전역적으로 저장하기 위한 인터페이스
+ *
+ * @author Daybreak312
+ * @since 27-03-2024
+ */
 interface ExceptionRepository {
 
     fun save(e: Exception)

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepositoryImpl.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package com.info.maeumgagym.error.repository
+
+import org.springframework.stereotype.Component
+
+@Component
+private class ExceptionRepositoryImpl : ExceptionRepository {
+
+    private val throwable: ThreadLocal<Exception?> = ThreadLocal.withInitial { null }
+
+    override fun save(e: Exception) {
+        this.throwable.set(e)
+    }
+
+    override fun throwIt() {
+        this.throwable.get()?.run {
+            this@ExceptionRepositoryImpl.throwable.remove()
+            throw this
+        }
+    }
+}

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepositoryImpl.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepositoryImpl.kt
@@ -2,6 +2,12 @@ package com.info.maeumgagym.error.repository
 
 import org.springframework.stereotype.Component
 
+/**
+ * Docs는 상위 타입에 존재
+ *
+ * @author Daybreak312
+ * @since 27-03-2024
+ */
 @Component
 private class ExceptionRepositoryImpl : ExceptionRepository {
 

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/filter/config/ApplicationFilterChainConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/filter/config/ApplicationFilterChainConfig.kt
@@ -5,6 +5,7 @@ import com.info.maeumgagym.error.filter.ErrorLogResponseFilter
 import com.info.maeumgagym.error.filter.ExceptionConvertFilter
 import com.info.maeumgagym.error.filter.filterchain.ExceptionChainedFilterChain
 import com.info.maeumgagym.error.filter.filterchain.ExceptionChainedFilterChainProxy
+import com.info.maeumgagym.error.repository.ExceptionRepository
 import com.info.maeumgagym.response.writer.DefaultHttpServletResponseWriter
 import com.info.maeumgagym.response.writer.ErrorLogHttpServletResponseWriter
 import org.springframework.boot.web.servlet.FilterRegistrationBean
@@ -23,7 +24,8 @@ import javax.servlet.ServletContext
 class ApplicationFilterChainConfig(
     private val servletContext: ServletContext,
     private val defaultHttpServletResponseWriter: DefaultHttpServletResponseWriter,
-    private val errorLogHttpServletResponseWriter: ErrorLogHttpServletResponseWriter
+    private val errorLogHttpServletResponseWriter: ErrorLogHttpServletResponseWriter,
+    private val exceptionRepository: ExceptionRepository
 ) {
 
     /**
@@ -47,7 +49,7 @@ class ApplicationFilterChainConfig(
                 ),
                 Pair(
                     ExceptionConvertFilter::class.simpleName!!,
-                    ExceptionConvertFilter()
+                    ExceptionConvertFilter(exceptionRepository)
                 )
             )
         )


### PR DESCRIPTION
#### 어떤 종류의 PR 인가요?
/kind 기능
<!--
Add one of the following kinds:
/kind 버그
/kind 리펙토링
/kind 문서
/kind 기능
-->

#### 이 PR이 무슨 일을 하나요? / 필요한 이유가 뭔가요?
Controller에서 LocalDate 타입의 parameter를 받을 때 발생할 수 있는 DateTimeException에 대해 예외 처리를 진행했습니다.

DispatcherServlet에 도달하면 DefaultHandlerExceptionResolver에 의해 자동으로 처리되기 때문에 ExceptionConvertorFilter에서 처리 할 수 없습니다.
그렇기에, DefaultHandlerExceptionResolver보다 더 먼저 실행되는 ExceptionHandlerExceptionResolver가 이를 처리하도록, ExceptionHandler를 사용했습니다.
그러나 ExceptionHandler를 사용하면 ErrorLogResponseFilter에서 처리할 수 없기 때문에 ExceptionRepository를 추가해, ExceptionHandler에서는 발생한 예외를 ExceptionRepository에 저장만 하고 ExecptionConvertFilter에서 다시 throw -> MaeumGaGymException으로 변환, 최종적으로 ErrorLogResponseFilter에서 처리하도록 작성했습니다.

#### 리뷰어를 위한 참고사항:

```docs

```
