### PR TITLE
PR :: SecurityFilterChain에서 발생한 Authentication 관련 예외를 ErrorLogResponseFilter에서 처리하도록 수정

### DIFF
--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/auth/ReadCurrentUserAdapter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/auth/ReadCurrentUserAdapter.kt
@@ -4,13 +4,11 @@ import com.info.maeumgagym.auth.port.out.ReadCurrentUserPort
 import com.info.maeumgagym.security.jwt.AuthenticationProvider
 import com.info.maeumgagym.security.jwt.JwtFilter
 import com.info.maeumgagym.user.model.User
-import com.info.maeumgagym.user.port.out.ReadUserPort
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 
 @Component
 internal class ReadCurrentUserAdapter(
-    private val readUserPort: ReadUserPort,
     private val authenticationProvider: AuthenticationProvider
 ) : ReadCurrentUserPort {
 

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ErrorLogResponseFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ErrorLogResponseFilter.kt
@@ -61,8 +61,10 @@ class ErrorLogResponseFilter(
     }
 
     private fun resolveUnknownException(e: Exception, response: HttpServletResponse) {
-        e.printStackTrace()
         val errorLog = printErrorLogAndReturn(e)
+
+        e.printStackTrace()
+
         errorLogHttpServletResponseWriter.writeResponseWithErrorLog(response, errorLog)
     }
 

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ErrorLogResponseFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ErrorLogResponseFilter.kt
@@ -57,13 +57,13 @@ class ErrorLogResponseFilter(
             e.printStackTrace()
         }
 
-        errorLogHttpServletResponseWriter.writeResponseWithErrorLogAndException(response, errorLog, e)
+        errorLogHttpServletResponseWriter.writeResponseWithErrorLog(response, errorLog)
     }
 
     private fun resolveUnknownException(e: Exception, response: HttpServletResponse) {
         e.printStackTrace()
         val errorLog = printErrorLogAndReturn(e)
-        errorLogHttpServletResponseWriter.writeResponseWithErrorLogAndException(response, errorLog, e)
+        errorLogHttpServletResponseWriter.writeResponseWithErrorLog(response, errorLog)
     }
 
     private fun isOkStatus(status: Int): Boolean =

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ErrorLogResponseFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ErrorLogResponseFilter.kt
@@ -1,7 +1,6 @@
 package com.info.maeumgagym.error.filter
 
 import com.info.maeumgagym.common.exception.*
-import com.info.maeumgagym.error.repository.ExceptionRepository
 import com.info.maeumgagym.error.vo.ErrorLog
 import com.info.maeumgagym.response.writer.DefaultHttpServletResponseWriter
 import com.info.maeumgagym.response.writer.ErrorLogHttpServletResponseWriter
@@ -29,8 +28,7 @@ import javax.servlet.http.HttpServletResponse
  */
 class ErrorLogResponseFilter(
     private val defaultHttpServletResponseWriter: DefaultHttpServletResponseWriter,
-    private val errorLogHttpServletResponseWriter: ErrorLogHttpServletResponseWriter,
-    private val exceptionRepository: ExceptionRepository
+    private val errorLogHttpServletResponseWriter: ErrorLogHttpServletResponseWriter
 ) : OncePerRequestFilter() {
 
     override fun doFilterInternal(
@@ -44,17 +42,6 @@ class ErrorLogResponseFilter(
             resolveMaeumGaGymException(e, response)
         } catch (e: Exception) {
             resolveUnknownException(e, response)
-        } finally {
-            resolveExceptionRepositoryException(response)
-        }
-    }
-
-    private fun resolveExceptionRepositoryException(response: HttpServletResponse) {
-        val e = exceptionRepository.get() ?: return
-
-        when (e) {
-            is MaeumGaGymException -> resolveMaeumGaGymException(e, response)
-            else -> resolveUnknownException(e, response)
         }
     }
 

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ErrorLogResponseFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ErrorLogResponseFilter.kt
@@ -19,7 +19,7 @@ import javax.servlet.http.HttpServletResponse
  *
  * 원래 [org.springframework.web.servlet.DispatcherServlet] 통과 이후 발생한 예외는 [NestedServletException.cause]로 감싸져 *throw*되지만, [ExceptionConvertFilter]에서 이를 [MaeumGaGymException]의 하위 타입으로 변환함. 자세한 것은 [ExceptionConvertFilter] 참조.
  *
- * 해당 *Filter*의 순서 설정 정보는 [com.info.maeumgagym.config.config.ApplicationFilterChainConfig]에 존재
+ * 해당 *Filter*의 순서 설정 정보는 [com.info.maeumgagym.filter.config.ApplicationFilterChainConfig]에 존재
  *
  * @see ExceptionConvertFilter
  *

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ErrorLogResponseFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ErrorLogResponseFilter.kt
@@ -73,7 +73,7 @@ class ErrorLogResponseFilter(
                     exceptionClassName = javaClass.name,
                     errorOccurredClassName = stackTrace[2].className + " or " + stackTrace[1].className,
                     status = status,
-                    message = fields.map {
+                    message = "$message, " + fields.map {
                         "${it.key}: ${it.value}"
                     }.toString()
                 )

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ErrorLogResponseFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ErrorLogResponseFilter.kt
@@ -1,6 +1,7 @@
 package com.info.maeumgagym.error.filter
 
 import com.info.maeumgagym.common.exception.*
+import com.info.maeumgagym.error.repository.ExceptionRepository
 import com.info.maeumgagym.error.vo.ErrorLog
 import com.info.maeumgagym.response.writer.DefaultHttpServletResponseWriter
 import com.info.maeumgagym.response.writer.ErrorLogHttpServletResponseWriter
@@ -28,7 +29,8 @@ import javax.servlet.http.HttpServletResponse
  */
 class ErrorLogResponseFilter(
     private val defaultHttpServletResponseWriter: DefaultHttpServletResponseWriter,
-    private val errorLogHttpServletResponseWriter: ErrorLogHttpServletResponseWriter
+    private val errorLogHttpServletResponseWriter: ErrorLogHttpServletResponseWriter,
+    private val exceptionRepository: ExceptionRepository
 ) : OncePerRequestFilter() {
 
     override fun doFilterInternal(
@@ -42,6 +44,17 @@ class ErrorLogResponseFilter(
             resolveMaeumGaGymException(e, response)
         } catch (e: Exception) {
             resolveUnknownException(e, response)
+        }
+        
+        resolveExceptionRepositoryException(response)
+    }
+
+    private fun resolveExceptionRepositoryException(response: HttpServletResponse) {
+        val e = exceptionRepository.get() ?: return
+
+        when (e) {
+            is MaeumGaGymException -> resolveMaeumGaGymException(e, response)
+            else -> resolveUnknownException(e, response)
         }
     }
 

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ErrorLogResponseFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ErrorLogResponseFilter.kt
@@ -44,9 +44,9 @@ class ErrorLogResponseFilter(
             resolveMaeumGaGymException(e, response)
         } catch (e: Exception) {
             resolveUnknownException(e, response)
+        } finally {
+            resolveExceptionRepositoryException(response)
         }
-        
-        resolveExceptionRepositoryException(response)
     }
 
     private fun resolveExceptionRepositoryException(response: HttpServletResponse) {

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ExceptionConvertFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ExceptionConvertFilter.kt
@@ -2,6 +2,7 @@ package com.info.maeumgagym.error.filter
 
 import com.info.maeumgagym.common.exception.MaeumGaGymException
 import com.info.maeumgagym.common.exception.PresentationValidationException
+import com.info.maeumgagym.error.repository.ExceptionRepository
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.filter.GenericFilterBean
@@ -27,18 +28,21 @@ import javax.validation.ConstraintViolationException
  * - Presentation 계층에서 Validation이 실패했을 경우 발생하는 예외 중 하나일 경우 [PresentationValidationException]으로 변환; 변환되는 타입 : [MethodArgumentNotValidException], [ConstraintViolationException], [MissingServletRequestParameterException]
  * - 그 외에는 그대로 변환
  *
- * 해당 *Filter*의 순서 설정 정보는 [com.info.maeumgagym.config.config.ApplicationFilterChainConfig]에 존재
+ * 해당 *Filter*의 순서 설정 정보는 [com.info.maeumgagym.filter.config.ApplicationFilterChainConfig]에 존재
  *
  * @see ErrorLogResponseFilter
  *
  * @author Daybreak312
  * @since 22.02.2024
  */
-class ExceptionConvertFilter : GenericFilterBean() {
+class ExceptionConvertFilter(
+    private val exceptionRepository: ExceptionRepository
+) : GenericFilterBean() {
 
     override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
         try {
             chain.doFilter(request, response)
+            exceptionRepository.throwIt()
         } catch (e: NestedServletException) {
             throw when (e.cause) {
                 is MaeumGaGymException -> e.cause as MaeumGaGymException

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ExceptionConvertFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ExceptionConvertFilter.kt
@@ -2,7 +2,6 @@ package com.info.maeumgagym.error.filter
 
 import com.info.maeumgagym.common.exception.MaeumGaGymException
 import com.info.maeumgagym.common.exception.PresentationValidationException
-import com.info.maeumgagym.error.repository.ExceptionRepository
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.filter.GenericFilterBean
@@ -35,14 +34,11 @@ import javax.validation.ConstraintViolationException
  * @author Daybreak312
  * @since 22.02.2024
  */
-class ExceptionConvertFilter(
-    private val exceptionRepository: ExceptionRepository
-) : GenericFilterBean() {
+class ExceptionConvertFilter : GenericFilterBean() {
 
     override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
         try {
             chain.doFilter(request, response)
-            exceptionRepository.get()
         } catch (e: NestedServletException) {
             throw when (e.cause) {
                 is MaeumGaGymException -> e.cause as MaeumGaGymException

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ExceptionConvertFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ExceptionConvertFilter.kt
@@ -81,7 +81,7 @@ class ExceptionConvertFilter(
         } catch (e: DateTimeException) {
             throw PresentationValidationException(
                 status = 400,
-                message = e.message ?: "DateTime Format Wrong",
+                message = "DateTime Format Wrong",
                 fields = mapOf()
             )
         }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ExceptionConvertFilter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/filter/ExceptionConvertFilter.kt
@@ -42,7 +42,7 @@ class ExceptionConvertFilter(
     override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
         try {
             chain.doFilter(request, response)
-            exceptionRepository.throwIt()
+            exceptionRepository.get()
         } catch (e: NestedServletException) {
             throw when (e.cause) {
                 is MaeumGaGymException -> e.cause as MaeumGaGymException

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/handler/CustomAccessDeniedHandler.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/handler/CustomAccessDeniedHandler.kt
@@ -1,12 +1,8 @@
 package com.info.maeumgagym.error.handler
 
+import com.info.maeumgagym.common.exception.AuthenticationException
+import com.info.maeumgagym.error.repository.ExceptionRepository
 import com.info.maeumgagym.security.env.CSRFProperties
-import com.info.maeumgagym.error.vo.ErrorResponse
-import com.info.maeumgagym.response.writer.DefaultHttpServletResponseWriter
-import mu.KLogger
-import mu.KotlinLogging
-import org.springframework.core.log.LogMessage
-import org.springframework.http.HttpStatus
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.web.access.AccessDeniedHandler
 import org.springframework.stereotype.Component
@@ -15,47 +11,23 @@ import javax.servlet.http.HttpServletResponse
 
 @Component
 class CustomAccessDeniedHandler(
-    private val defaultHttpServletResponseWriter: DefaultHttpServletResponseWriter,
+    private val exceptionRepository: ExceptionRepository,
     private val csrfProperties: CSRFProperties
 ) : AccessDeniedHandler {
-
-    private var errorPage: String? = null
-
-    private companion object {
-        val logger: KLogger = KotlinLogging.logger {}
-    }
 
     override fun handle(
         request: HttpServletRequest,
         response: HttpServletResponse,
         accessDeniedException: AccessDeniedException
     ) {
-        if (response.isCommitted) {
-            logger.trace { "Did not write to response since already committed" }
-        } else if (this.errorPage == null) {
-            logger.debug { "Responding with 403 status code" }
-
-            val errorResponse = if (request.getHeader(csrfProperties.header) == null) {
-                ErrorResponse(403, "CSRF Token Not in Possession")
+        try {
+            throw if (request.getHeader(csrfProperties.header) == null) {
+                AuthenticationException(403, "CSRF Token Not in Possession")
             } else {
-                ErrorResponse(403, "Invalid CSRF Token")
+                AuthenticationException(403, "Invalid CSRF Token")
             }
-
-            defaultHttpServletResponseWriter.doDefaultSettingWithStatusCode(response, HttpStatus.FORBIDDEN.value())
-            defaultHttpServletResponseWriter.setBody(response, errorResponse)
-        } else {
-            request.setAttribute("SPRING_SECURITY_403_EXCEPTION", accessDeniedException)
-            response.status = HttpStatus.FORBIDDEN.value()
-            if (logger.isDebugEnabled) {
-                logger.debug {
-                    LogMessage.format(
-                        "Forwarding to %s with status code 403",
-                        this.errorPage
-                    )
-                }
-            }
-
-            request.getRequestDispatcher(this.errorPage).forward(request, response)
+        } catch (e: AuthenticationException) {
+            exceptionRepository.save(e)
         }
     }
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/handler/CustomAuthenticationEntryPoint.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/handler/CustomAuthenticationEntryPoint.kt
@@ -27,6 +27,5 @@ class CustomAuthenticationEntryPoint(
         } catch (e: AuthenticationException) {
             exceptionRepository.save(e)
         }
-
     }
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/handler/CustomExceptionHandler.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/handler/CustomExceptionHandler.kt
@@ -1,0 +1,17 @@
+package com.info.maeumgagym.error.handler
+
+import com.info.maeumgagym.error.repository.ExceptionRepository
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+import java.time.DateTimeException
+
+@ControllerAdvice
+class CustomExceptionHandler(
+    private val exceptionRepository: ExceptionRepository
+) {
+
+    @ExceptionHandler(DateTimeException::class)
+    fun dateTimeExceptionHandler(e: DateTimeException) {
+        exceptionRepository.save(e)
+    }
+}

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepository.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepository.kt
@@ -1,0 +1,9 @@
+package com.info.maeumgagym.error.repository
+
+interface ExceptionRepository {
+
+    fun save(e: Exception)
+
+    @Throws(Exception::class)
+    fun throwIt()
+}

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepository.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepository.kt
@@ -11,5 +11,5 @@ interface ExceptionRepository {
     fun save(e: Exception)
 
     @Throws(Exception::class)
-    fun throwIt()
+    fun get()
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepository.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepository.kt
@@ -1,7 +1,7 @@
 package com.info.maeumgagym.error.repository
 
 /**
- * 경우에 따라, 생성된 Exception을 저장해두었다가 다른 위치에서 발생시킬 수 있도록 Thread에 전역적으로 저장하기 위한 인터페이스
+ * 생성된 Exception을 저장해두었다가 다른 위치에서 이용할 수 있도록 Thread에 전역적으로 저장하기 위한 인터페이스
  *
  * @author Daybreak312
  * @since 27-03-2024
@@ -10,6 +10,5 @@ interface ExceptionRepository {
 
     fun save(e: Exception)
 
-    @Throws(Exception::class)
     fun get(): Exception?
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepository.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepository.kt
@@ -11,5 +11,5 @@ interface ExceptionRepository {
     fun save(e: Exception)
 
     @Throws(Exception::class)
-    fun get()
+    fun get(): Exception?
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepository.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepository.kt
@@ -1,5 +1,11 @@
 package com.info.maeumgagym.error.repository
 
+/**
+ * 경우에 따라, 생성된 Exception을 저장해두었다가 다른 위치에서 발생시킬 수 있도록 Thread에 전역적으로 저장하기 위한 인터페이스
+ *
+ * @author Daybreak312
+ * @since 27-03-2024
+ */
 interface ExceptionRepository {
 
     fun save(e: Exception)

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepository.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepository.kt
@@ -10,5 +10,6 @@ interface ExceptionRepository {
 
     fun save(e: Exception)
 
-    fun get(): Exception?
+    @Throws(Exception::class)
+    fun throwIt()
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepositoryImpl.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package com.info.maeumgagym.error.repository
+
+import org.springframework.stereotype.Component
+
+@Component
+private class ExceptionRepositoryImpl : ExceptionRepository {
+
+    private val throwable: ThreadLocal<Exception?> = ThreadLocal.withInitial { null }
+
+    override fun save(e: Exception) {
+        this.throwable.set(e)
+    }
+
+    override fun throwIt() {
+        this.throwable.get()?.run {
+            this@ExceptionRepositoryImpl.throwable.remove()
+            throw this
+        }
+    }
+}

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepositoryImpl.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepositoryImpl.kt
@@ -2,6 +2,12 @@ package com.info.maeumgagym.error.repository
 
 import org.springframework.stereotype.Component
 
+/**
+ * Docs는 상위 타입에 존재
+ *
+ * @author Daybreak312
+ * @since 27-03-2024
+ */
 @Component
 private class ExceptionRepositoryImpl : ExceptionRepository {
 

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepositoryImpl.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepositoryImpl.kt
@@ -17,9 +17,11 @@ private class ExceptionRepositoryImpl : ExceptionRepository {
         this.throwable.set(e)
     }
 
-    override fun get(): Exception? {
-        return this.throwable.get()?.apply {
+    @Throws(Exception::class)
+    override fun throwIt() {
+        this.throwable.get()?.apply {
             this@ExceptionRepositoryImpl.throwable.remove()
+            throw this
         }
     }
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepositoryImpl.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepositoryImpl.kt
@@ -17,10 +17,9 @@ private class ExceptionRepositoryImpl : ExceptionRepository {
         this.throwable.set(e)
     }
 
-    override fun get() {
-        this.throwable.get()?.run {
+    override fun get(): Exception? {
+        return this.throwable.get()?.apply {
             this@ExceptionRepositoryImpl.throwable.remove()
-            throw this
         }
     }
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepositoryImpl.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/repository/ExceptionRepositoryImpl.kt
@@ -17,7 +17,7 @@ private class ExceptionRepositoryImpl : ExceptionRepository {
         this.throwable.set(e)
     }
 
-    override fun throwIt() {
+    override fun get() {
         this.throwable.get()?.run {
             this@ExceptionRepositoryImpl.throwable.remove()
             throw this

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/vo/ErrorLog.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/vo/ErrorLog.kt
@@ -11,6 +11,7 @@ data class ErrorLog(
     val errorOccurredClassName: String,
     val status: Int = 500,
     val message: String? = null,
+    val map: Map<String, String> = mapOf(),
     val timestamp: LocalDateTime = LocalDateTime.now()
 ) {
     companion object {
@@ -21,9 +22,8 @@ data class ErrorLog(
                         exceptionClassName = javaClass.name,
                         errorOccurredClassName = stackTrace[2].className + " or " + stackTrace[1].className,
                         status = status,
-                        message = "$message, " + fields.map {
-                            "${it.key}: ${it.value}"
-                        }.toString()
+                        message = message,
+                        map = fields
                     )
                 }
 

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/vo/ErrorLog.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/error/vo/ErrorLog.kt
@@ -1,5 +1,7 @@
 package com.info.maeumgagym.error.vo
 
+import com.info.maeumgagym.common.exception.MaeumGaGymException
+import com.info.maeumgagym.common.exception.PresentationValidationException
 import java.time.LocalDateTime
 import java.util.*
 
@@ -10,4 +12,40 @@ data class ErrorLog(
     val status: Int = 500,
     val message: String? = null,
     val timestamp: LocalDateTime = LocalDateTime.now()
-)
+) {
+    companion object {
+        fun of(e: Exception) =
+            when (e) {
+                is PresentationValidationException -> e.run {
+                    ErrorLog(
+                        exceptionClassName = javaClass.name,
+                        errorOccurredClassName = stackTrace[2].className + " or " + stackTrace[1].className,
+                        status = status,
+                        message = "$message, " + fields.map {
+                            "${it.key}: ${it.value}"
+                        }.toString()
+                    )
+                }
+
+                is MaeumGaGymException -> e.run {
+                    ErrorLog(
+                        exceptionClassName = javaClass.name,
+                        errorOccurredClassName = stackTrace[2].className + " or " + stackTrace[1].className,
+                        status = status,
+                        message = message
+                    )
+                }
+
+                else -> e.run {
+                    ErrorLog(
+                        exceptionClassName = javaClass.name,
+                        errorOccurredClassName = stackTrace[2].className + " or " + stackTrace[1].className,
+                        message = message
+                    )
+                }
+            }
+    }
+
+    override fun toString() =
+        "[$id] $status : \"$message\" in $errorOccurredClassName cause $exceptionClassName"
+}

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/filter/chained/ChainedFilterChain.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/filter/chained/ChainedFilterChain.kt
@@ -75,7 +75,7 @@ abstract class ChainedFilterChain : GlobalFilterChain {
 
         plusCurrentFilterIndex()
 
-        if (currentFilterIndex.get() == filters.size - 2) {
+        if (currentFilterIndex.get() == filters.size - 1) {
             getCurrentFilter().doFilter(request, response, calledFilterChain.get())
         } else {
             getCurrentFilter().doFilter(request, response, this)

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/filter/config/ApplicationFilterChainConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/filter/config/ApplicationFilterChainConfig.kt
@@ -45,11 +45,15 @@ class ApplicationFilterChainConfig(
             mapOf(
                 Pair(
                     ErrorLogResponseFilter::class.simpleName!!,
-                    ErrorLogResponseFilter(defaultHttpServletResponseWriter, errorLogHttpServletResponseWriter)
+                    ErrorLogResponseFilter(
+                        defaultHttpServletResponseWriter,
+                        errorLogHttpServletResponseWriter,
+                        exceptionRepository
+                    )
                 ),
                 Pair(
                     ExceptionConvertFilter::class.simpleName!!,
-                    ExceptionConvertFilter(exceptionRepository)
+                    ExceptionConvertFilter()
                 )
             )
         )

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/filter/config/ApplicationFilterChainConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/filter/config/ApplicationFilterChainConfig.kt
@@ -5,6 +5,7 @@ import com.info.maeumgagym.error.filter.ErrorLogResponseFilter
 import com.info.maeumgagym.error.filter.ExceptionConvertFilter
 import com.info.maeumgagym.error.filter.filterchain.ExceptionChainedFilterChain
 import com.info.maeumgagym.error.filter.filterchain.ExceptionChainedFilterChainProxy
+import com.info.maeumgagym.error.repository.ExceptionRepository
 import com.info.maeumgagym.response.writer.DefaultHttpServletResponseWriter
 import com.info.maeumgagym.response.writer.ErrorLogHttpServletResponseWriter
 import org.springframework.boot.web.servlet.FilterRegistrationBean
@@ -23,7 +24,8 @@ import javax.servlet.ServletContext
 class ApplicationFilterChainConfig(
     private val servletContext: ServletContext,
     private val defaultHttpServletResponseWriter: DefaultHttpServletResponseWriter,
-    private val errorLogHttpServletResponseWriter: ErrorLogHttpServletResponseWriter
+    private val errorLogHttpServletResponseWriter: ErrorLogHttpServletResponseWriter,
+    private val exceptionRepository: ExceptionRepository
 ) {
 
     /**
@@ -47,7 +49,7 @@ class ApplicationFilterChainConfig(
                 ),
                 Pair(
                     ExceptionConvertFilter::class.simpleName!!,
-                    ExceptionConvertFilter()
+                    ExceptionConvertFilter(exceptionRepository)
                 )
             )
         )

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/filter/config/ApplicationFilterChainConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/filter/config/ApplicationFilterChainConfig.kt
@@ -46,13 +46,14 @@ class ApplicationFilterChainConfig(
                     ErrorLogResponseFilter::class.simpleName!!,
                     ErrorLogResponseFilter(
                         defaultHttpServletResponseWriter,
-                        errorLogHttpServletResponseWriter,
-                        exceptionRepository
+                        errorLogHttpServletResponseWriter
                     )
                 ),
                 Pair(
                     ExceptionConvertFilter::class.simpleName!!,
-                    ExceptionConvertFilter()
+                    ExceptionConvertFilter(
+                        exceptionRepository
+                    )
                 )
             )
         )

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/filter/config/SecurityFilterChainConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/filter/config/SecurityFilterChainConfig.kt
@@ -48,13 +48,14 @@ class SecurityFilterChainConfig(
                                 ErrorLogResponseFilter::class.simpleName!!,
                                 ErrorLogResponseFilter(
                                     defaultHttpServletResponseWriter,
-                                    errorLogHttpServletResponseWriter,
-                                    exceptionRepository
+                                    errorLogHttpServletResponseWriter
                                 )
                             ),
                             Pair(
                                 ExceptionConvertFilter::class.simpleName!!,
-                                ExceptionConvertFilter()
+                                ExceptionConvertFilter(
+                                    exceptionRepository
+                                )
                             )
                         )
                     )

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/response/writer/ErrorLogHttpServletResponseWriter.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/response/writer/ErrorLogHttpServletResponseWriter.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 import javax.servlet.http.HttpServletResponse
 
 /**
- * [ErrorLog] 및 [Exception]을 [HttpServletResponse]로 작성하기 위한 [HttpServletResponseWriter].
+ * [ErrorLog]의 정보로 [HttpServletResponse]를 작성하기 위한 [HttpServletResponseWriter].
  *
  * [DefaultHttpServletResponseWriter]를 내부 변수로 갖고 있어, [setBody]와 [doDefaultSettingWithStatusCode]는 [DefaultHttpServletResponseWriter]를 통해 Proxy 형태로 구현됨.
  *
@@ -36,7 +36,7 @@ abstract class ErrorLogHttpServletResponseWriter : HttpServletResponseWriter {
     ): HttpServletResponse
 
     /**
-     * 인자로 받은 [ErrorLog]와 [Exception]의 정보를 기반으로 [HttpServletResponse]를 작성.
+     * 인자로 받은 [ErrorLog]의 정보를 기반으로 [HttpServletResponse]를 작성.
      *
      * 사용되는 정보는 [ErrorLogResponse]의 Docs 참고.
      *
@@ -45,10 +45,9 @@ abstract class ErrorLogHttpServletResponseWriter : HttpServletResponseWriter {
      * @author Daybreak312
      * @since 12-03-2024
      */
-    abstract fun writeResponseWithErrorLogAndException(
+    abstract fun writeResponseWithErrorLog(
         response: HttpServletResponse,
-        errorLog: ErrorLog,
-        e: Exception
+        errorLog: ErrorLog
     ): HttpServletResponse
 }
 
@@ -70,4 +69,18 @@ data class ErrorLogResponse(
     val errorLogId: String,
     val timestamp: LocalDateTime = LocalDateTime.now(),
     val map: Map<String, String> = mapOf()
-)
+) {
+
+    companion object {
+        fun of(errorLog: ErrorLog): ErrorLogResponse =
+            errorLog.run {
+                ErrorLogResponse(
+                    status = status,
+                    message = message,
+                    errorLogId = id,
+                    timestamp = timestamp,
+                    map = map
+                )
+            }
+    }
+}

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/response/writer/impl/ErrorLogHttpServletResponseWriterImpl.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/response/writer/impl/ErrorLogHttpServletResponseWriterImpl.kt
@@ -1,6 +1,5 @@
 package com.info.maeumgagym.response.writer.impl
 
-import com.info.maeumgagym.common.exception.PresentationValidationException
 import com.info.maeumgagym.error.vo.ErrorLog
 import com.info.maeumgagym.response.writer.DefaultHttpServletResponseWriter
 import com.info.maeumgagym.response.writer.ErrorLogHttpServletResponseWriter
@@ -28,23 +27,14 @@ private class ErrorLogHttpServletResponseWriterImpl(
     ): HttpServletResponse =
         defaultHttpServletResponseWriter.doDefaultSettingWithStatusCode(response, status)
 
-    override fun writeResponseWithErrorLogAndException(
+    override fun writeResponseWithErrorLog(
         response: HttpServletResponse,
-        errorLog: ErrorLog,
-        e: Exception
+        errorLog: ErrorLog
     ): HttpServletResponse = response.apply {
         doDefaultSettingWithStatusCode(response, errorLog.status)
         setBody(
             response = response,
-            `object` = errorLog.let {
-                ErrorLogResponse(
-                    status = it.status,
-                    message = it.message,
-                    errorLogId = it.id,
-                    timestamp = it.timestamp,
-                    map = if (e is PresentationValidationException) e.fields else mapOf()
-                )
-            }
+            `object` = ErrorLogResponse.of(errorLog)
         )
     }
 }

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/config/SecurityConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/config/SecurityConfig.kt
@@ -1,8 +1,8 @@
 package com.info.maeumgagym.security.config
 
-import com.info.maeumgagym.filter.config.SecurityFilterChainConfig
 import com.info.maeumgagym.error.handler.CustomAccessDeniedHandler
 import com.info.maeumgagym.error.handler.CustomAuthenticationEntryPoint
+import com.info.maeumgagym.filter.config.SecurityFilterChainConfig
 import com.info.maeumgagym.security.env.CSRFProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/config/cors/CorsConfig.kt
+++ b/maeumgagym-infrastructure/src/main/kotlin/com/info/maeumgagym/security/config/cors/CorsConfig.kt
@@ -13,7 +13,14 @@ class CorsConfig(private val securityProperty: SecurityProperties) {
     @Bean
     fun corsConfigurationSource(): CorsConfigurationSource {
         val configuration = CorsConfiguration().apply {
-            allowedOrigins = listOf(securityProperty.frontDomain, securityProperty.backDomain)
+            allowedOrigins = listOf(
+                securityProperty.frontDomain,
+                securityProperty.backDomain,
+                "https://maeumgagym-main-stag.xquare.app",
+                "https://maeumgagym-user-stag.xquare.app",
+                "https://maeumgagym-admin-stag.xquare.app",
+                "http://localhost:3000"
+            )
             allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD")
             allowCredentials = true
             addAllowedHeader("*")


### PR DESCRIPTION
#### 어떤 종류의 PR 인가요?
/kind 기능
/kind 리펙토링
<!--
Add one of the following kinds:
/kind 버그
/kind 리펙토링
/kind 문서
/kind 기능
-->

#### 이 PR이 무슨 일을 하나요? / 필요한 이유가 뭔가요?
SecurityFilterChain 실행 중에 인증이 실패하면, AccessDeniedHandler 혹은 AuthenticationEntryPoint로 Handle되는데, 이렇게 Handle된 예외를 해당 클래스에서 처리하지 않고 AuthenticationException으로만 전환하고 ErrorLogResponseFilter에서 처리하도록 했습니다.

또한, 이 PR에는 #186 의 변경 사항이 포함되어 있습니다.

#### 리뷰어를 위한 참고사항:

```docs
1. AccessDeniedHandler에 있던, 이미 에러 페이지가 있을 경우에 대한 로직을 제거한 이유
Exception이 발생하고, 이를 Spring에서 처리해 errorPage를 로딩할 경우 사용자가 Controller까지 가기 위한 여정을 다시 경험하게 됩니다.
이러한 부분을 불필요하고, 비효율적인 로직이라 판단했기에 마음가짐에서 Spring의 ErrorPage를 제공하는 경우를 모두 없애려 합니다.
이러한 제 견해를 실행에 옮기기 위한, 기나길 리펙토링 여행의 첫 걸음입니다.

사실 이 변경점과 앞서 언급한 문제점과는 별 연관이 없지만, 그래도 에러 페이지의 존재 가능성을 제거하고자 해당 로직 또한 제거했습니다.

```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206937090191548